### PR TITLE
Improve project finance flows and budget visibility

### DIFF
--- a/src/components/CitizenCommunication.jsx
+++ b/src/components/CitizenCommunication.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.jsx';
 import { Button } from '@/components/ui/button.jsx';
 import { Badge } from '@/components/ui/badge.jsx';
@@ -65,7 +65,7 @@ import {
   Newspaper,
   Video
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { 
   CitizenGroups,
   CitizenGroupLabels,
@@ -166,9 +166,44 @@ const CitizenCommunication = () => {
     setSelectedGroup(null);
   };
 
+  const resolveGroupInfo = (groupKeyOrId) => {
+    return (
+      groups[groupKeyOrId] ||
+      Object.values(groups).find(group => group.group === groupKeyOrId) ||
+      citizenGroupsData.find(group => group.group === groupKeyOrId || group.id === groupKeyOrId) ||
+      null
+    );
+  };
+
   const filteredIssues = activeIssues
     .filter(issue => filterGroup === 'all' || issue.group === filterGroup)
     .filter(issue => filterType === 'all' || issue.type === filterType);
+
+  const highlightedIssue = selectedIssue || filteredIssues[0] || null;
+  const highlightedGroup = highlightedIssue ? resolveGroupInfo(highlightedIssue.group) : null;
+  const selectedGroupReference = selectedGroup ? resolveGroupInfo(selectedGroup.id) : null;
+
+  useEffect(() => {
+    if (filteredIssues.length === 0) {
+      if (selectedIssue) {
+        setSelectedIssue(null);
+      }
+      return;
+    }
+
+    const issueStillVisible = selectedIssue && filteredIssues.some(issue => issue.id === selectedIssue.id);
+    if (!issueStillVisible) {
+      setSelectedIssue(filteredIssues[0]);
+    }
+  }, [filteredIssues, selectedIssue]);
+
+  useEffect(() => {
+    if (selectedIssue) {
+      setResponseType('');
+      setResponseAmount(selectedIssue.cost);
+      setResponseMessage('');
+    }
+  }, [selectedIssue]);
 
   const overallSatisfaction = citizenHelpers.calculateOverallSatisfaction(groups);
   const protestPotential = citizenHelpers.calculateProtestPotential(groups);
@@ -301,6 +336,51 @@ const CitizenCommunication = () => {
             </CardContent>
           </Card>
 
+          {highlightedIssue && (
+            <Card>
+              <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500">Приоритетное обращение</div>
+                  <div className="font-semibold">{highlightedIssue.title}</div>
+                  <div className="text-xs text-gray-500 mt-1">
+                    Стоимость решения: {citizenHelpers.formatAmount(highlightedIssue.cost)}
+                  </div>
+                </div>
+                {highlightedGroup && (
+                  <div>
+                    <div className="text-gray-500">Группа</div>
+                    <div className="font-semibold flex items-center gap-2">
+                      {CitizenGroupLabels[highlightedGroup.group]}
+                      <Badge variant="outline">Удовл. {highlightedGroup.satisfaction}%</Badge>
+                    </div>
+                    <div className="text-xs text-gray-500 mt-1">
+                      Предпочитаемые каналы: {highlightedGroup.preferredChannels
+                        .slice(0, 2)
+                        .map(channel => CommunicationChannelLabels[channel])
+                        .join(', ')}
+                    </div>
+                  </div>
+                )}
+                <div>
+                  <div className="text-gray-500">Рекомендуемый ответ</div>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {(highlightedIssue.expectedResponse || []).map((type) => (
+                      <Badge key={type} variant="outline" className="text-xs">
+                        {ResponseTypeLabels[type]}
+                      </Badge>
+                    ))}
+                    {highlightedIssue.expectedResponse?.length === 0 && (
+                      <span className="text-xs text-gray-500">Нет рекомендаций</span>
+                    )}
+                  </div>
+                  <div className="text-xs text-gray-500 mt-2">
+                    Поддержка: {highlightedIssue.support} человек • Срочность: {highlightedIssue.urgency}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
           {/* Список обращений */}
           {filteredIssues.length > 0 ? (
             <div className="space-y-4">
@@ -308,9 +388,15 @@ const CitizenCommunication = () => {
                 const IssueIcon = getIssueIcon(issue.type);
                 const ChannelIcon = getChannelIcon(issue.channel);
                 const group = groups[`bryansk_${issue.group}`];
-                
+
                 return (
-                  <Card key={issue.id} className="hover:shadow-lg transition-shadow">
+                  <Card
+                    key={issue.id}
+                    className={`hover:shadow-lg transition-shadow ${
+                      selectedIssue?.id === issue.id ? 'ring-2 ring-blue-500' : ''
+                    }`}
+                    onMouseEnter={() => setSelectedIssue(issue)}
+                  >
                     <CardContent className="p-6">
                       <div className="flex items-start justify-between mb-4">
                         <div className="flex items-start gap-3">
@@ -575,9 +661,14 @@ const CitizenCommunication = () => {
               const GroupIcon = getGroupIcon(group.group);
               const satisfactionColor = citizenHelpers.getSatisfactionColor(group.satisfaction);
               const influenceColor = citizenHelpers.getInfluenceColor(group.influence);
-              
               return (
-                <Card key={group.id} className="hover:shadow-lg transition-shadow">
+                <Card
+                  key={group.id}
+                  className={`hover:shadow-lg transition-shadow ${
+                    selectedGroup?.id === group.id ? 'ring-2 ring-blue-500' : ''
+                  }`}
+                  onMouseEnter={() => setSelectedGroup(group)}
+                >
                   <CardHeader>
                     <CardTitle className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
@@ -762,6 +853,62 @@ const CitizenCommunication = () => {
               );
             })}
           </div>
+
+          {selectedGroup && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Фокус: {selectedGroup.name}</span>
+                  <Badge variant="outline">Влияние {selectedGroup.influence}%</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div>
+                    <div className="text-gray-500">Удовлетворенность</div>
+                    <div className={citizenHelpers.getSatisfactionColor(selectedGroup.satisfaction)}>
+                      {selectedGroup.satisfaction}%
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-gray-500">Протестный потенциал</div>
+                    <div className="font-semibold">{selectedGroup.characteristics.protest_potential}%</div>
+                  </div>
+                  <div>
+                    <div className="text-gray-500">Население</div>
+                    <div className="font-semibold">{selectedGroup.population.toLocaleString('ru-RU')} чел.</div>
+                  </div>
+                </div>
+
+                {selectedGroupReference?.preferredChannels && (
+                  <div className="text-xs text-gray-500">
+                    Источник данных: профайл «{selectedGroupReference.name}». Предпочитаемые каналы: {selectedGroupReference
+                      .preferredChannels
+                      .slice(0, 3)
+                      .map(channel => CommunicationChannelLabels[channel])
+                      .join(', ')}.
+                  </div>
+                )}
+
+                <div>
+                  <div className="text-gray-500 mb-1">Актуальные проблемы</div>
+                  <div className="flex flex-wrap gap-2">
+                    {citizenIssues
+                      .filter(issue => issue.group === selectedGroup.group)
+                      .slice(0, 3)
+                      .map(issue => (
+                        <Badge key={issue.id} variant="outline" className="text-xs">
+                          {issue.title}
+                        </Badge>
+                      ))}
+                    {citizenIssues.filter(issue => issue.group === selectedGroup.group).length === 0 && (
+                      <span className="text-xs text-gray-500">Нет зарегистрированных обращений</span>
+                    )}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         {/* Собрания и встречи */}

--- a/src/components/ConstructionManager.jsx
+++ b/src/components/ConstructionManager.jsx
@@ -75,7 +75,7 @@ import {
   SortAsc,
   SortDesc
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { 
   ConstructionTypes,
   ConstructionTypeLabels,
@@ -177,8 +177,18 @@ const ConstructionManager = () => {
 
   const overallUtilityQuality = constructionHelpers.calculateUtilityQuality(utilities);
   const totalPopulation = Object.values(districts).reduce((sum, district) => sum + district.population, 0);
-  const averageInfrastructure = Object.values(districts).reduce((sum, district) => 
+  const averageInfrastructure = Object.values(districts).reduce((sum, district) =>
     sum + district.infrastructure_quality, 0) / Object.keys(districts).length;
+  const selectedProjectDetails = selectedProject ? selectedProject : null;
+  const selectedProjectEconomics = selectedProjectDetails ?
+    constructionHelpers.calculateEconomicImpact(selectedProjectDetails) : null;
+  const selectedProjectRequirements = selectedProjectDetails ?
+    constructionHelpers.checkProjectRequirements(selectedProjectDetails, gameState) : null;
+  const selectedProjectRisks = selectedProjectDetails ?
+    constructionHelpers.evaluateProjectRisks(selectedProjectDetails, gameState) : null;
+  const selectedUtilityData = selectedUtility ? utilities[selectedUtility] : null;
+  const selectedUtilityUpgrades = selectedUtility ?
+    utilityServices.filter(service => service.type === selectedUtility) : [];
 
   return (
     <div className="space-y-6">
@@ -256,6 +266,20 @@ const ConstructionManager = () => {
                 </p>
               </div>
               <Zap className="w-8 h-8 text-orange-600" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-gray-600">Население под управлением</p>
+                <p className="text-2xl font-bold text-blue-600">
+                  {totalPopulation.toLocaleString('ru-RU')}
+                </p>
+              </div>
+              <MapPin className="w-8 h-8 text-blue-600" />
             </div>
           </CardContent>
         </Card>
@@ -375,9 +399,15 @@ const ConstructionManager = () => {
               const risks = constructionHelpers.evaluateProjectRisks(project, gameState);
               const economicImpact = constructionHelpers.calculateEconomicImpact(project);
               const priority = constructionHelpers.calculateProjectPriority(project, gameState);
-              
+
               return (
-                <Card key={project.id} className="hover:shadow-lg transition-shadow">
+                <Card
+                  key={project.id}
+                  className={`hover:shadow-lg transition-shadow ${
+                    selectedProject?.id === project.id ? 'ring-2 ring-blue-500' : ''
+                  }`}
+                  onMouseEnter={() => setSelectedProject(project)}
+                >
                   <CardHeader>
                     <CardTitle className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
@@ -462,11 +492,11 @@ const ConstructionManager = () => {
                     </div>
 
                     <Dialog>
-                      <DialogTrigger asChild>
-                        <Button 
-                          className="w-full"
-                          onClick={() => setSelectedProject(project)}
-                          disabled={!requirements.all_met}
+                          <DialogTrigger asChild>
+                            <Button
+                              className="w-full"
+                              onClick={() => setSelectedProject(project)}
+                              disabled={!requirements.all_met}
                         >
                           Подробнее
                         </Button>
@@ -688,6 +718,68 @@ const ConstructionManager = () => {
               );
             })}
           </div>
+
+          {selectedProjectDetails && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Выбранный проект: {selectedProjectDetails.name}</span>
+                  <Badge variant="outline">{ConstructionTypeLabels[selectedProjectDetails.type]}</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                {selectedProjectEconomics && (
+                  <div>
+                    <div className="text-gray-500">Экономический эффект</div>
+                    <div className="font-semibold text-green-600">
+                      {constructionHelpers.formatAmount(selectedProjectEconomics.total_impact)}
+                    </div>
+                    <div className="text-xs text-gray-500 mt-1">
+                      ROI: {selectedProjectEconomics.roi_percentage.toFixed(1)}%
+                    </div>
+                  </div>
+                )}
+                {selectedProjectRequirements && (
+                  <div>
+                    <div className="text-gray-500">Требования</div>
+                    <div className="space-y-1 mt-1">
+                      {Object.entries(selectedProjectRequirements)
+                        .filter(([key]) => key !== 'all_met')
+                        .map(([key, met]) => (
+                          <div key={key} className="flex items-center gap-2">
+                            {met ? (
+                              <CheckCircle className="w-3 h-3 text-green-600" />
+                            ) : (
+                              <AlertTriangle className="w-3 h-3 text-red-600" />
+                            )}
+                            <span className="text-xs capitalize">{key.replace(/_/g, ' ')}</span>
+                          </div>
+                        ))}
+                    </div>
+                  </div>
+                )}
+                {selectedProjectRisks && (
+                  <div>
+                    <div className="text-gray-500">Уровень риска</div>
+                    <div className={`font-semibold ${
+                      selectedProjectRisks.risk_level === 'high'
+                        ? 'text-red-600'
+                        : selectedProjectRisks.risk_level === 'medium'
+                          ? 'text-yellow-600'
+                          : 'text-green-600'
+                    }`}>
+                      {selectedProjectRisks.total_risk}%
+                    </div>
+                    {selectedProjectRisks.recommendations.length > 0 && (
+                      <div className="text-xs text-gray-500 mt-1">
+                        {selectedProjectRisks.recommendations.join(', ')}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         {/* Коммунальные услуги */}
@@ -696,9 +788,15 @@ const ConstructionManager = () => {
             {Object.entries(utilities).map(([type, data]) => {
               const UtilityIcon = getUtilityIcon(type);
               const averageScore = (data.coverage * 0.6 + data.quality * 0.4);
-              
+
               return (
-                <Card key={type} className="hover:shadow-lg transition-shadow">
+                <Card
+                  key={type}
+                  className={`hover:shadow-lg transition-shadow ${
+                    selectedUtility === type ? 'ring-2 ring-blue-500' : ''
+                  }`}
+                  onMouseEnter={() => setSelectedUtility(type)}
+                >
                   <CardHeader>
                     <CardTitle className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
@@ -850,6 +948,47 @@ const ConstructionManager = () => {
               );
             })}
           </div>
+
+          {selectedUtilityData && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Выбранная услуга: {UtilityTypeLabels[selectedUtility]}</span>
+                  <Badge variant="outline">Состояние {selectedUtilityData.quality}%</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div>
+                    <div className="text-gray-500">Покрытие</div>
+                    <div className="font-semibold">{selectedUtilityData.coverage}%</div>
+                  </div>
+                  <div>
+                    <div className="text-gray-500">Качество</div>
+                    <div className="font-semibold">{selectedUtilityData.quality}%</div>
+                  </div>
+                  <div>
+                    <div className="text-gray-500">Удовлетворенность</div>
+                    <div className="font-semibold">{selectedUtilityData.satisfaction}%</div>
+                  </div>
+                </div>
+                {selectedUtilityUpgrades.length > 0 ? (
+                  <div>
+                    <div className="text-gray-500 mb-1">Доступные модернизации</div>
+                    <div className="flex flex-wrap gap-2">
+                      {selectedUtilityUpgrades.map((service) => (
+                        <Badge key={service.id} variant="outline" className="text-xs">
+                          {service.name}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-gray-500">Нет предложений по улучшению</div>
+                )}
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         {/* Районы города */}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -14,7 +14,7 @@ import {
   Calendar,
   Clock
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { gameStateHelpers } from '../types/game.js';
 
 const Dashboard = () => {
@@ -30,19 +30,6 @@ const Dashboard = () => {
       if (value >= 70) return 'text-green-600';
       if (value >= 40) return 'text-yellow-600';
       return 'text-red-600';
-    }
-  };
-
-  // Функция для получения цвета прогресс-бара
-  const getProgressColor = (value, reverse = false) => {
-    if (reverse) {
-      if (value <= 5) return 'bg-green-500';
-      if (value <= 10) return 'bg-yellow-500';
-      return 'bg-red-500';
-    } else {
-      if (value >= 70) return 'bg-green-500';
-      if (value >= 40) return 'bg-yellow-500';
-      return 'bg-red-500';
     }
   };
 

--- a/src/components/EventModal.jsx
+++ b/src/components/EventModal.jsx
@@ -18,7 +18,7 @@ import {
   TrendingDown,
   Info
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { gameStateHelpers } from '../types/game.js';
 
 const EventModal = () => {

--- a/src/components/GameControls.jsx
+++ b/src/components/GameControls.jsx
@@ -19,7 +19,7 @@ import {
   AlertTriangle,
   CheckCircle
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 
 const GameControls = () => {
   const { gameState, actions, computed } = useGame();

--- a/src/components/GovernmentManagement.jsx
+++ b/src/components/GovernmentManagement.jsx
@@ -49,7 +49,7 @@ import {
   Zap,
   Shield
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { 
   GovernmentDepartments,
   DepartmentLabels,
@@ -140,11 +140,17 @@ const GovernmentManagement = () => {
   };
 
   const departmentEfficiency = governmentHelpers.calculateDepartmentEfficiency(
-    selectedDepartment, 
+    selectedDepartment,
     currentDepartmentEmployees
   );
 
   const departmentCost = governmentHelpers.calculateDepartmentCost(currentDepartmentEmployees);
+  const currentEmployeeIds = new Set(Object.values(employees).flat().map(employee => employee.id));
+  const talentPool = employeesData
+    .filter(candidate => !currentEmployeeIds.has(candidate.id))
+    .sort((a, b) => b.qualities.competence - a.qualities.competence)
+    .slice(0, 3);
+  const selectedEmployeeRisk = selectedEmployee ? governmentHelpers.calculateResignationRisk(selectedEmployee) : null;
 
   return (
     <div className="space-y-6">
@@ -522,6 +528,44 @@ const GovernmentManagement = () => {
               </Card>
             </div>
           </div>
+
+          {selectedPolicy && (() => {
+            const policyDetails = policyOptions.find(item => item.id === selectedPolicy);
+            if (!policyDetails) return null;
+            return (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    <span>Выбранная политика: {policyDetails.name}</span>
+                    <Badge variant="outline">{policyDetails.duration} дней</Badge>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                  <div>
+                    <div className="text-gray-500">Департамент</div>
+                    <div className="font-semibold">{DepartmentLabels[policyDetails.department]}</div>
+                    <div className="text-xs text-gray-500 mt-1">Стоимость: {policyDetails.cost.toLocaleString('ru-RU')} ₽</div>
+                  </div>
+                  <div>
+                    <div className="text-gray-500">Ключевые эффекты</div>
+                    <div className="space-y-1 mt-1">
+                      {Object.entries(policyDetails.effects).map(([effect, value]) => (
+                        <div key={effect} className={`text-xs ${value >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                          {effect}: {value >= 0 ? '+' : ''}{value}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-gray-500">Дополнительно</div>
+                    <div className="text-xs text-gray-600 mt-1">
+                      {policyDetails.description}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })()}
         </TabsContent>
 
         {/* Все сотрудники */}
@@ -587,7 +631,11 @@ const GovernmentManagement = () => {
                         </TableCell>
                         <TableCell>
                           <div className="flex gap-1">
-                            <Button size="sm" variant="outline">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => setSelectedEmployee(employee)}
+                            >
                               Управление
                             </Button>
                             {resignationRisk > 70 && (
@@ -604,6 +652,77 @@ const GovernmentManagement = () => {
               </Table>
             </CardContent>
           </Card>
+
+          {selectedEmployee && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Выбранный сотрудник: {selectedEmployee.name}</span>
+                  <Badge variant="outline">Риск ухода {selectedEmployeeRisk}%</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500">Департамент</div>
+                  <div className="font-semibold">{DepartmentLabels[selectedEmployee.department]}</div>
+                  <div className="text-xs text-gray-500 mt-1">Опыт: {selectedEmployee.experience} лет</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Качества</div>
+                  <div className="space-y-1 mt-1">
+                    {Object.entries(selectedEmployee.qualities).map(([quality, value]) => (
+                      <div key={quality} className="flex justify-between text-xs">
+                        <span>{QualityLabels[quality]}</span>
+                        <span className="font-medium">{value}%</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Рекомендации</div>
+                  <div className="text-xs text-gray-600 mt-1">
+                    Рекомендуемая зарплата: {governmentHelpers.calculateRecommendedSalary(selectedEmployee).toLocaleString('ru-RU')} ₽
+                    <br />Настроение: {selectedEmployee.mood}%
+                  </div>
+                  {selectedEmployeeRisk > 60 && (
+                    <Badge variant="destructive" className="mt-2">Высокий риск ухода</Badge>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {talentPool.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Кадровый резерв</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+                {talentPool.map((candidate) => (
+                  <div key={candidate.id} className="p-3 border rounded-lg">
+                    <div className="font-semibold">{candidate.name}</div>
+                    <div className="text-xs text-gray-500 mb-2">{candidate.position}</div>
+                    <div className="flex justify-between text-xs">
+                      <span>Компетентность</span>
+                      <span className="font-medium">{candidate.qualities[EmployeeQualities.COMPETENCE]}%</span>
+                    </div>
+                    <div className="flex justify-between text-xs">
+                      <span>Лояльность</span>
+                      <span className="font-medium">{candidate.qualities[EmployeeQualities.LOYALTY]}%</span>
+                    </div>
+                    <Button
+                      size="sm"
+                      className="w-full mt-2"
+                      variant="outline"
+                      onClick={() => setSelectedDepartment(candidate.department)}
+                    >
+                      Перейти к отделу
+                    </Button>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         {/* Политики */}
@@ -615,13 +734,19 @@ const GovernmentManagement = () => {
               <div className="space-y-3">
                 {policyOptions.map((policy) => {
                   const canImplement = governmentHelpers.canImplementPolicy(
-                    policy, 
-                    policy.department, 
+                    policy,
+                    policy.department,
                     employees[policy.department]
                   );
-                  
+
                   return (
-                    <Card key={policy.id} className="hover:shadow-md transition-shadow">
+                    <Card
+                      key={policy.id}
+                      className={`hover:shadow-md transition-shadow ${
+                        selectedPolicy === policy.id ? 'ring-2 ring-blue-500' : ''
+                      }`}
+                      onMouseEnter={() => setSelectedPolicy(policy.id)}
+                    >
                       <CardContent className="p-4">
                         <div className="flex items-start justify-between mb-2">
                           <div>

--- a/src/components/IndustryManager.jsx
+++ b/src/components/IndustryManager.jsx
@@ -57,7 +57,7 @@ import {
   ThumbsUp,
   ThumbsDown
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { 
   IndustryTypes,
   IndustryLabels,
@@ -664,6 +664,36 @@ const IndustryManager = () => {
                   </Card>
                 );
               })}
+
+              {completedProjects.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Завершенные проекты</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2 text-sm">
+                    {completedProjects.slice(-5).reverse().map((project) => {
+                      const Icon = getIndustryIcon(project.industry);
+                      return (
+                        <div key={project.id} className="flex items-center justify-between p-2 border rounded">
+                          <div className="flex items-center gap-2">
+                            <Icon className="w-4 h-4 text-blue-600" />
+                            <div>
+                              <div className="font-medium">{project.name}</div>
+                              <div className="text-xs text-gray-500">
+                                Завершен: {new Date(project.completedAt || Date.now()).toLocaleDateString('ru-RU')}
+                              </div>
+                            </div>
+                          </div>
+                          <div className="text-right">
+                            <div className="text-xs text-gray-500">Откаты</div>
+                            <div className="font-semibold text-green-600">{industryHelpers.formatAmount(project.kickbacksReceived || 0)}</div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </CardContent>
+                </Card>
+              )}
             </div>
           ) : (
             <Card>
@@ -686,11 +716,17 @@ const IndustryManager = () => {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {enterprises.map((enterprise) => {
               const Icon = getIndustryIcon(enterprise.industry);
-              const modernizationROI = enterprise.modernizationNeeded ? 
+              const modernizationROI = enterprise.modernizationNeeded ?
                 industryHelpers.calculateModernizationROI(enterprise, enterprise.modernizationCost) : null;
-              
+
               return (
-                <Card key={enterprise.id} className="hover:shadow-md transition-shadow">
+                <Card
+                  key={enterprise.id}
+                  className={`hover:shadow-md transition-shadow ${
+                    selectedEnterprise?.id === enterprise.id ? 'ring-2 ring-blue-500' : ''
+                  }`}
+                  onMouseEnter={() => setSelectedEnterprise(enterprise)}
+                >
                   <CardHeader>
                     <CardTitle className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
@@ -847,6 +883,39 @@ const IndustryManager = () => {
               );
             })}
           </div>
+
+          {selectedEnterprise && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Выбранное предприятие: {selectedEnterprise.name}</span>
+                  <Badge variant="outline">{IndustryLabels[selectedEnterprise.industry]}</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500">Сотрудники</div>
+                  <div className="font-semibold">{selectedEnterprise.employees.toLocaleString('ru-RU')}</div>
+                  <div className="text-xs text-gray-500 mt-1">Выручка: {industryHelpers.formatAmount(selectedEnterprise.annualRevenue)}</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Налоговые поступления</div>
+                  <div className="font-semibold text-purple-600">{industryHelpers.formatAmount(selectedEnterprise.taxContribution)}</div>
+                  <div className="text-xs text-gray-500 mt-1">Статус: {selectedEnterprise.status}</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Потенциал модернизации</div>
+                  {selectedEnterprise.modernizationNeeded ? (
+                    <div className="text-xs text-green-600 mt-1">
+                      Возможный рост эффективности: +{selectedEnterprise.modernizationBenefits.efficiency}%<br />Новые рабочие места: +{selectedEnterprise.modernizationBenefits.jobs}
+                    </div>
+                  ) : (
+                    <div className="text-xs text-gray-500 mt-1">Модернизация не требуется</div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         {/* История откатов */}

--- a/src/components/InvestmentManager.jsx
+++ b/src/components/InvestmentManager.jsx
@@ -54,7 +54,7 @@ import {
   Eye,
   Filter
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { 
   InvestmentSectors,
   SectorLabels,
@@ -80,6 +80,7 @@ const InvestmentManager = () => {
   const completedInvestments = investmentState.completedInvestments || [];
   const portfolio = investmentState.portfolio || {};
   const investmentMetrics = investmentState.investmentMetrics || {};
+  const selectedInvestmentDetails = selectedInvestment || null;
 
   const getSectorIcon = (sector) => {
     const icons = {
@@ -322,9 +323,15 @@ const InvestmentManager = () => {
               const canInvest = investmentHelpers.canInvest(investment, investment.minInvestment, gameState);
               const expectedReturn = investmentHelpers.calculateExpectedReturn(investment, gameState);
               const riskScore = investmentHelpers.calculateInvestmentRisk(investment, gameState);
-              
+
               return (
-                <Card key={investment.id} className="hover:shadow-lg transition-shadow">
+                <Card
+                  key={investment.id}
+                  className={`hover:shadow-lg transition-shadow ${
+                    selectedInvestment?.id === investment.id ? 'ring-2 ring-blue-500' : ''
+                  }`}
+                  onMouseEnter={() => setSelectedInvestment(investment)}
+                >
                   <CardHeader>
                     <CardTitle className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
@@ -558,6 +565,44 @@ const InvestmentManager = () => {
               );
             })}
           </div>
+
+          {selectedInvestmentDetails && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Выбранная возможность: {selectedInvestmentDetails.name}</span>
+                  <Badge variant="outline">{SectorLabels[selectedInvestmentDetails.sector]}</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500">Минимальные инвестиции</div>
+                  <div className="font-semibold">{investmentHelpers.formatAmount(selectedInvestmentDetails.minInvestment)}</div>
+                  <div className="text-xs text-gray-500 mt-1">Срок: {selectedInvestmentDetails.duration} мес.</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Ожидаемая доходность</div>
+                  <div className="font-semibold text-green-600">
+                    {investmentHelpers.calculateExpectedReturn(selectedInvestmentDetails, gameState).toFixed(1)}% годовых
+                  </div>
+                  <div className="text-xs text-gray-500 mt-1">Риск: {investmentHelpers.calculateInvestmentRisk(selectedInvestmentDetails, gameState).toFixed(0)}%</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Ключевые выгоды</div>
+                  <div className="space-y-1 mt-1 text-xs">
+                    {selectedInvestmentDetails.cityBenefits && Object.entries(selectedInvestmentDetails.cityBenefits).map(([benefit, value]) => (
+                      <div key={benefit} className={value >= 0 ? 'text-green-600' : 'text-red-600'}>
+                        {benefit}: {value >= 0 ? '+' : ''}{value}
+                      </div>
+                    ))}
+                    {!selectedInvestmentDetails.cityBenefits && (
+                      <span className="text-gray-500">Дополнительные выгоды не указаны</span>
+                    )}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         {/* Активные инвестиции */}
@@ -648,6 +693,39 @@ const InvestmentManager = () => {
                   </Card>
                 );
               })}
+
+              {completedInvestments.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Завершенные инвестиции</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2 text-sm">
+                    {completedInvestments.slice(-5).reverse().map((investment) => {
+                      const originalInvestment = investmentOpportunities.find(inv => inv.id === investment.id);
+                      if (!originalInvestment) return null;
+                      const Icon = getSectorIcon(originalInvestment.sector);
+                      const totalReturn = investment.profit || 0;
+                      const percent = investment.returnPercent || (investment.amount > 0 ? (totalReturn / investment.amount) * 100 : 0);
+                      return (
+                        <div key={investment.id} className="flex items-center justify-between p-2 border rounded">
+                          <div className="flex items-center gap-2">
+                            <Icon className="w-4 h-4 text-blue-600" />
+                            <div>
+                              <div className="font-medium">{originalInvestment.name}</div>
+                              <div className="text-xs text-gray-500">
+                                Доход: {investmentHelpers.formatAmount(totalReturn)} ({percent >= 0 ? '+' : ''}{percent.toFixed(1)}%)
+                              </div>
+                            </div>
+                          </div>
+                          <div className="text-xs text-gray-500">
+                            Завершено: {new Date(investment.completedAt || Date.now()).toLocaleDateString('ru-RU')}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </CardContent>
+                </Card>
+              )}
             </div>
           ) : (
             <Card>
@@ -667,6 +745,28 @@ const InvestmentManager = () => {
 
         {/* Портфель */}
         <TabsContent value="portfolio" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Сводка портфеля</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+              <div>
+                <div className="text-gray-500">Инвестировано</div>
+                <div className="font-semibold">{investmentHelpers.formatAmount(portfolio.totalInvested || 0)}</div>
+              </div>
+              <div>
+                <div className="text-gray-500">Текущая стоимость</div>
+                <div className="font-semibold text-green-600">{investmentHelpers.formatAmount(portfolio.activeValue || 0)}</div>
+              </div>
+              <div>
+                <div className="text-gray-500">Полученная прибыль</div>
+                <div className={`font-semibold ${ (portfolio.totalReturns || 0) >= 0 ? 'text-green-600' : 'text-red-600' }`}>
+                  {investmentHelpers.formatAmount(portfolio.totalReturns || 0)}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {/* Распределение по секторам */}
             <Card>

--- a/src/components/PersonalSpendingManager.jsx
+++ b/src/components/PersonalSpendingManager.jsx
@@ -79,7 +79,7 @@ import {
   Settings,
   MoreHorizontal
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { 
   SpendingCategories,
   SpendingCategoryLabels,
@@ -138,12 +138,16 @@ const PersonalSpendingManager = () => {
     .filter(option => filterRisk === 'all' || option.risk_level === filterRisk)
     .sort((a, b) => {
       switch (sortBy) {
-        case 'cost': return a.cost - b.cost;
-        case 'risk': 
+        case 'cost':
+          return a.cost - b.cost;
+        case 'risk': {
           const riskOrder = { very_low: 1, low: 2, medium: 3, high: 4, very_high: 5 };
           return riskOrder[a.risk_level] - riskOrder[b.risk_level];
-        case 'detection': return a.detection_probability - b.detection_probability;
-        default: return 0;
+        }
+        case 'detection':
+          return a.detection_probability - b.detection_probability;
+        default:
+          return 0;
       }
     });
 
@@ -354,9 +358,15 @@ const PersonalSpendingManager = () => {
               const CategoryIcon = getCategoryIcon(option.category);
               const availability = personalSpendingHelpers.checkAvailability(option, gameState);
               const ratingImpact = personalSpendingHelpers.calculateRatingImpact(option, gameState);
-              
+
               return (
-                <Card key={option.id} className="hover:shadow-lg transition-shadow">
+                <Card
+                  key={option.id}
+                  className={`hover:shadow-lg transition-shadow ${
+                    selectedOption?.id === option.id ? 'ring-2 ring-blue-500' : ''
+                  }`}
+                  onMouseEnter={() => setSelectedOption(option)}
+                >
                   <CardHeader>
                     <CardTitle className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
@@ -602,6 +612,42 @@ const PersonalSpendingManager = () => {
               );
             })}
           </div>
+
+          {selectedOption && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Выбранная трата: {selectedOption.name}</span>
+                  <Badge variant="outline">{SpendingCategoryLabels[selectedOption.category]}</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500">Стоимость</div>
+                  <div className="font-semibold">{personalSpendingHelpers.formatAmount(selectedOption.cost)}</div>
+                  <div className="text-xs text-gray-500 mt-1">Тип: {SpendingTypeLabels[selectedOption.type]}</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Риск обнаружения</div>
+                  <div className={`font-semibold ${personalSpendingHelpers.getRiskColor(selectedOption.risk_level)}`}>
+                    {selectedOption.detection_probability}%
+                  </div>
+                  <div className="text-xs text-gray-500 mt-1">Рейтинг: {personalSpendingHelpers.calculateRatingImpact(selectedOption, gameState).toFixed(1)}%</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Выгоды</div>
+                  <div className="space-y-1 mt-1 text-xs">
+                    {Object.entries(selectedOption.benefits).map(([benefit, value]) => (
+                      <div key={benefit} className="flex justify-between">
+                        <span>{benefit}</span>
+                        <span className="font-medium">{typeof value === 'number' ? value : value}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         {/* Активы */}

--- a/src/components/ProjectsPanel.jsx
+++ b/src/components/ProjectsPanel.jsx
@@ -28,7 +28,7 @@ import {
   TrendingUp,
   TrendingDown
 } from 'lucide-react';
-import { useGame } from '../contexts/GameContext.jsx';
+import { useGame } from '../hooks/useGame.js';
 import { cityProjects, projectHelpers } from '../data/projects.js';
 import { ProjectCategories } from '../types/game.js';
 import { gameStateHelpers } from '../types/game.js';
@@ -96,9 +96,8 @@ const ProjectsPanel = () => {
 
   const availableProjects = cityProjects.filter(project => {
     const isNotActive = !gameState.activeProjects?.some(active => active.id === project.id);
-    const canStart = projectHelpers.canStartProject(project, gameState);
     const categoryMatch = selectedCategory === 'all' || project.category === selectedCategory;
-    
+
     return isNotActive && categoryMatch;
   });
 
@@ -123,7 +122,13 @@ const ProjectsPanel = () => {
     const canAfford = gameStateHelpers.canAffordAction(gameState, project.cost);
 
     return (
-      <Card key={project.id} className="hover:shadow-md transition-shadow">
+      <Card
+        key={project.id}
+        className={`hover:shadow-md transition-shadow ${
+          !isActive && selectedProject?.id === project.id ? 'ring-2 ring-blue-500' : ''
+        }`}
+        onMouseEnter={!isActive ? () => setSelectedProject(project) : undefined}
+      >
         <CardHeader className="pb-3">
           <div className="flex items-start justify-between">
             <div className="flex items-center gap-2">
@@ -387,6 +392,42 @@ const ProjectsPanel = () => {
               </Card>
             )}
           </div>
+
+          {selectedProject && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Выбранный проект: {selectedProject.title}</span>
+                  <Badge variant="outline">{categoryLabels[selectedProject.category]}</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500">Стоимость</div>
+                  <div className="font-semibold">{gameStateHelpers.formatMoney(selectedProject.cost)}</div>
+                  <div className="text-xs text-gray-500 mt-1">Длительность: {selectedProject.duration} дней</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Ежемесячные расходы</div>
+                  <div className="font-semibold text-red-600">{selectedProject.monthlyCost ? gameStateHelpers.formatMoney(selectedProject.monthlyCost) : '—'}</div>
+                  <div className="text-xs text-gray-500 mt-1">Сложность: {getDifficultyLabel(selectedProject.difficulty)}</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Основные эффекты</div>
+                  <div className="space-y-1 mt-1 text-xs">
+                    {selectedProject.effects && Object.entries(selectedProject.effects).map(([key, value]) => (
+                      <div key={key} className={value >= 0 ? 'text-green-600' : 'text-red-600'}>
+                        {key}: {value >= 0 ? '+' : ''}{value}
+                      </div>
+                    ))}
+                    {!selectedProject.effects && (
+                      <span className="text-gray-500">Эффекты не указаны</span>
+                    )}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/ui/alert-dialog.jsx
+++ b/src/components/ui/alert-dialog.jsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
 import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button-variants"
 
 function AlertDialog({
   ...props

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -41,4 +41,4 @@ function Badge({
   );
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/src/components/ui/button-variants.js
+++ b/src/components/ui/button-variants.js
@@ -1,0 +1,32 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,39 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva } from "class-variance-authority";
-
 import { cn } from "@/lib/utils"
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { buttonVariants } from "./button-variants"
 
 function Button({
   className,
@@ -52,4 +20,4 @@ function Button({
   );
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/src/components/ui/calendar.jsx
+++ b/src/components/ui/calendar.jsx
@@ -3,7 +3,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button-variants"
 
 function Calendar({
   className,

--- a/src/components/ui/form.jsx
+++ b/src/components/ui/form.jsx
@@ -132,7 +132,6 @@ function FormMessage({
 }
 
 export {
-  useFormField,
   Form,
   FormItem,
   FormLabel,

--- a/src/components/ui/navigation-menu.jsx
+++ b/src/components/ui/navigation-menu.jsx
@@ -148,5 +148,4 @@ export {
   NavigationMenuLink,
   NavigationMenuIndicator,
   NavigationMenuViewport,
-  navigationMenuTriggerStyle,
 }

--- a/src/components/ui/pagination.jsx
+++ b/src/components/ui/pagination.jsx
@@ -6,7 +6,7 @@ import {
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button-variants";
 
 function Pagination({
   className,

--- a/src/components/ui/sidebar.jsx
+++ b/src/components/ui/sidebar.jsx
@@ -678,5 +678,4 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 }

--- a/src/components/ui/toggle-group.jsx
+++ b/src/components/ui/toggle-group.jsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
 
 import { cn } from "@/lib/utils"
-import { toggleVariants } from "@/components/ui/toggle"
+import { toggleVariants } from "@/components/ui/toggle-variants"
 
 const ToggleGroupContext = React.createContext({
   size: "default",

--- a/src/components/ui/toggle-variants.js
+++ b/src/components/ui/toggle-variants.js
@@ -1,0 +1,23 @@
+import { cva } from "class-variance-authority";
+
+export const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);

--- a/src/components/ui/toggle.jsx
+++ b/src/components/ui/toggle.jsx
@@ -1,30 +1,7 @@
 import * as React from "react"
 import * as TogglePrimitive from "@radix-ui/react-toggle"
-import { cva } from "class-variance-authority";
-
 import { cn } from "@/lib/utils"
-
-const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
-  {
-    variants: {
-      variant: {
-        default: "bg-transparent",
-        outline:
-          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
-      },
-      size: {
-        default: "h-9 px-2 min-w-9",
-        sm: "h-8 px-1.5 min-w-8",
-        lg: "h-10 px-2.5 min-w-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { toggleVariants } from "./toggle-variants"
 
 function Toggle({
   className,
@@ -40,4 +17,4 @@ function Toggle({
   );
 }
 
-export { Toggle, toggleVariants }
+export { Toggle }

--- a/src/contexts/GameContext.jsx
+++ b/src/contexts/GameContext.jsx
@@ -1,7 +1,17 @@
-import React, { createContext, useContext, useReducer, useEffect } from 'react';
-import { initialGameState } from '../types/game.js';
+import React, { createContext, useReducer, useEffect } from 'react';
+import { createInitialGameState, initialGameState, GameConstants } from '../types/game.js';
 import { gameLogic } from '../utils/gameLogic.js';
-import { initialFinanceState, financeHelpers } from '../types/finance.js';
+import { projectHelpers } from '../data/projects.js';
+import { initialFinanceState, financeHelpers, PersonalAccountTypes, BudgetCategories, IncomeTypes } from '../types/finance.js';
+import { initialBankingState, bankingHelpers, BankAccountTypes, LoanTypes, DepositTypes, loanOffers, depositOffers } from '../types/banking.js';
+import { initialGovernmentState, governmentHelpers, policyOptions, PositionLevels, GovernmentDepartments } from '../types/government.js';
+import { initialInvestmentState, investmentHelpers, investmentOpportunities } from '../types/investments.js';
+import { initialIndustryState, industryHelpers, industrialProjects, ProjectStatus } from '../types/industry.js';
+import { initialSecurityState, securityHelpers, OperationTypes, InfluenceLevels, ThreatLevels } from '../types/security.js';
+import { initialCitizensState, citizenHelpers, citizenIssues, ResponseTypes } from '../types/citizens.js';
+import { initialTaxationState, taxationHelpers, taxPolicies, TaxTypes, RevenueCategories, ExpenditureCategories } from '../types/taxation.js';
+import { initialConstructionState, constructionHelpers, constructionProjects, ConstructionPhases, utilityServices } from '../types/construction.js';
+import { initialPersonalSpendingState, personalSpendingHelpers, personalSpendingOptions, SpendingTypes } from '../types/personalSpending.js';
 
 // Создаем контекст
 const GameContext = createContext();
@@ -20,23 +30,2152 @@ const GAME_ACTIONS = {
   CLEAR_ERROR: 'CLEAR_ERROR',
   // Новые действия для финансовой системы
   REALLOCATE_BUDGET: 'REALLOCATE_BUDGET',
+  APPLY_BUDGET_CHANGES: 'APPLY_BUDGET_CHANGES',
   PERFORM_CORRUPTION: 'PERFORM_CORRUPTION',
-  TRANSFER_PERSONAL_FUNDS: 'TRANSFER_PERSONAL_FUNDS',
-  UPDATE_FINANCE_STATE: 'UPDATE_FINANCE_STATE'
+  UPDATE_FINANCE_STATE: 'UPDATE_FINANCE_STATE',
+  BUY_STOCK: 'BUY_STOCK',
+  SELL_STOCK: 'SELL_STOCK',
+  TRANSFER_FUNDS: 'TRANSFER_FUNDS',
+  TAKE_LOAN: 'TAKE_LOAN',
+  CREATE_DEPOSIT: 'CREATE_DEPOSIT',
+  PROMOTE_EMPLOYEE: 'PROMOTE_EMPLOYEE',
+  FIRE_EMPLOYEE: 'FIRE_EMPLOYEE',
+  CHANGE_EMPLOYEE_SALARY: 'CHANGE_EMPLOYEE_SALARY',
+  IMPLEMENT_POLICY: 'IMPLEMENT_POLICY',
+  MAKE_GOVERNMENT_DECISION: 'MAKE_GOVERNMENT_DECISION',
+  MAKE_INVESTMENT: 'MAKE_INVESTMENT',
+  WITHDRAW_INVESTMENT: 'WITHDRAW_INVESTMENT',
+  IMPLEMENT_INDUSTRIAL_PROJECT: 'IMPLEMENT_INDUSTRIAL_PROJECT',
+  MODERNIZE_ENTERPRISE: 'MODERNIZE_ENTERPRISE',
+  EXECUTE_SECURITY_OPERATION: 'EXECUTE_SECURITY_OPERATION',
+  MITIGATE_THREAT: 'MITIGATE_THREAT',
+  RESPOND_TO_ISSUE: 'RESPOND_TO_ISSUE',
+  SCHEDULE_MEETING: 'SCHEDULE_MEETING',
+  IMPLEMENT_TAX_POLICY: 'IMPLEMENT_TAX_POLICY',
+  CHANGE_TAX_RATE: 'CHANGE_TAX_RATE',
+  START_CONSTRUCTION_PROJECT: 'START_CONSTRUCTION_PROJECT',
+  UPGRADE_UTILITY: 'UPGRADE_UTILITY',
+  MAKE_PERSONAL_PURCHASE: 'MAKE_PERSONAL_PURCHASE'
+};
+
+const deepClone = (value) => JSON.parse(JSON.stringify(value));
+
+const clamp = (value, min = 0, max = 100) => {
+  if (Number.isNaN(value)) return min;
+  return Math.max(min, Math.min(max, value));
+};
+
+const buildPersonalFinancesSnapshot = (personalFinances) => ({
+  personal_account: personalFinances?.accounts?.[PersonalAccountTypes.CHECKING] || 0,
+  savings_account: personalFinances?.accounts?.[PersonalAccountTypes.SAVINGS] || 0,
+  offshore_account: personalFinances?.accounts?.[PersonalAccountTypes.OFFSHORE] || 0,
+  crypto_account: personalFinances?.accounts?.[PersonalAccountTypes.CRYPTO] || 0,
+  cash: personalFinances?.accounts?.[PersonalAccountTypes.CASH] || 0,
+  monthlyIncome: deepClone(personalFinances?.monthlyIncome || {}),
+  monthlyExpenses: deepClone(personalFinances?.monthlyExpenses || {})
+});
+
+const PERSONAL_BANK_ACCOUNT_MAP = {
+  [BankAccountTypes.PERSONAL_CHECKING]: PersonalAccountTypes.CHECKING,
+  [BankAccountTypes.PERSONAL_SAVINGS]: PersonalAccountTypes.SAVINGS,
+  [BankAccountTypes.PERSONAL_INVESTMENT]: PersonalAccountTypes.SAVINGS,
+  [BankAccountTypes.OFFSHORE]: PersonalAccountTypes.OFFSHORE
+};
+
+const mergeGameState = (savedState = {}) => {
+  const base = createInitialGameState();
+  const incoming = deepClone(savedState);
+
+  const merged = {
+    ...base,
+    ...incoming,
+    financeState: { ...base.financeState, ...(incoming.financeState || {}) },
+    bankingState: { ...base.bankingState, ...(incoming.bankingState || {}) },
+    governmentState: { ...base.governmentState, ...(incoming.governmentState || {}) },
+    investmentState: { ...base.investmentState, ...(incoming.investmentState || {}) },
+    industryState: { ...base.industryState, ...(incoming.industryState || {}) },
+    securityState: { ...base.securityState, ...(incoming.securityState || {}) },
+    citizensState: { ...base.citizensState, ...(incoming.citizensState || {}) },
+    taxationState: { ...base.taxationState, ...(incoming.taxationState || {}) },
+    constructionState: { ...base.constructionState, ...(incoming.constructionState || {}) },
+    personalSpendingState: { ...base.personalSpendingState, ...(incoming.personalSpendingState || {}) }
+  };
+
+  merged.personalFinances = incoming.personalFinances
+    ? { ...base.personalFinances, ...incoming.personalFinances }
+    : buildPersonalFinancesSnapshot(merged.financeState.personalFinances);
+
+  merged.citizenGroups = incoming.citizenGroups
+    ? { ...base.citizenGroups, ...incoming.citizenGroups }
+    : deepClone(merged.citizensState.groups);
+
+  if (!merged.citizensState.activeIssues || merged.citizensState.activeIssues.length === 0) {
+    merged.citizensState = {
+      ...merged.citizensState,
+      activeIssues: citizenIssues.slice(0, 3).map((issue) => ({ ...issue }))
+    };
+  }
+
+  return merged;
+};
+
+const handleBuyStock = (state, payload = {}) => {
+  const { stockId, quantity, price, accountType, commission = 0 } = payload;
+
+  if (!stockId || !quantity || quantity <= 0 || !price || !accountType) {
+    return { ...state, errorMessage: 'Некорректные параметры операции' };
+  }
+
+  const bankingState = deepClone(state.bankingState || initialBankingState);
+  const account = bankingState.accounts?.[accountType];
+
+  if (!account) {
+    return { ...state, errorMessage: 'Выбранный банковский счет недоступен' };
+  }
+
+  const totalCost = price * quantity + commission;
+  if ((account.balance || 0) < totalCost) {
+    return { ...state, errorMessage: 'Недостаточно средств на счете для покупки акций' };
+  }
+
+  bankingState.accounts[accountType] = {
+    ...account,
+    balance: account.balance - totalCost
+  };
+
+  const portfolioKey = accountType.includes('personal') ? 'personal' : 'city';
+  const currentPortfolio = bankingState.stockPortfolio?.[portfolioKey] || {};
+  const existing = currentPortfolio[stockId] || { quantity: 0, averagePrice: 0 };
+  const newQuantity = existing.quantity + quantity;
+  const newAveragePrice = newQuantity > 0
+    ? ((existing.averagePrice * existing.quantity) + (price * quantity)) / newQuantity
+    : price;
+
+  bankingState.stockPortfolio = {
+    ...bankingState.stockPortfolio,
+    [portfolioKey]: {
+      ...currentPortfolio,
+      [stockId]: {
+        quantity: newQuantity,
+        averagePrice: newAveragePrice
+      }
+    }
+  };
+
+  bankingState.transactionHistory = [
+    {
+      id: Date.now(),
+      type: 'buy_stock',
+      stockId,
+      quantity,
+      price,
+      commission,
+      accountType,
+      total: totalCost,
+      timestamp: Date.now()
+    },
+    ...(bankingState.transactionHistory || [])
+  ].slice(0, 100);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+
+  if (portfolioKey === 'city') {
+    financeState.cityBudget = {
+      ...financeState.cityBudget,
+      total: Math.max(0, (financeState.cityBudget.total || 0) - totalCost)
+    };
+    budget = Math.max(0, budget - totalCost);
+  } else {
+    const mappedAccount = PERSONAL_BANK_ACCOUNT_MAP[accountType];
+    if (mappedAccount) {
+      const current = financeState.personalFinances?.accounts?.[mappedAccount] || 0;
+      financeState.personalFinances = {
+        ...financeState.personalFinances,
+        accounts: {
+          ...financeState.personalFinances.accounts,
+          [mappedAccount]: Math.max(0, current - totalCost)
+        }
+      };
+    }
+  }
+
+  return {
+    ...state,
+    errorMessage: null,
+    bankingState,
+    financeState,
+    budget,
+    personalFinances: buildPersonalFinancesSnapshot(financeState.personalFinances)
+  };
+};
+
+const handleSellStock = (state, payload = {}) => {
+  const { stockId, quantity, price, accountType, commission = 0 } = payload;
+
+  if (!stockId || !quantity || quantity <= 0 || !price || !accountType) {
+    return { ...state, errorMessage: 'Некорректные параметры операции продажи' };
+  }
+
+  const bankingState = deepClone(state.bankingState || initialBankingState);
+  const portfolioKey = accountType.includes('personal') ? 'personal' : 'city';
+  const currentPortfolio = bankingState.stockPortfolio?.[portfolioKey] || {};
+  const existing = currentPortfolio[stockId];
+
+  if (!existing || existing.quantity < quantity) {
+    return { ...state, errorMessage: 'Недостаточно акций для продажи' };
+  }
+
+  const account = bankingState.accounts?.[accountType];
+  if (!account) {
+    return { ...state, errorMessage: 'Счет для зачисления средств не найден' };
+  }
+
+  const grossAmount = price * quantity;
+  const netAmount = Math.max(0, grossAmount - commission);
+  const newQuantity = existing.quantity - quantity;
+
+  const updatedPortfolio = { ...currentPortfolio };
+  if (newQuantity > 0) {
+    updatedPortfolio[stockId] = {
+      ...existing,
+      quantity: newQuantity
+    };
+  } else {
+    delete updatedPortfolio[stockId];
+  }
+
+  bankingState.stockPortfolio = {
+    ...bankingState.stockPortfolio,
+    [portfolioKey]: updatedPortfolio
+  };
+
+  bankingState.accounts[accountType] = {
+    ...account,
+    balance: (account.balance || 0) + netAmount
+  };
+
+  bankingState.transactionHistory = [
+    {
+      id: Date.now(),
+      type: 'sell_stock',
+      stockId,
+      quantity,
+      price,
+      commission,
+      accountType,
+      total: netAmount,
+      timestamp: Date.now()
+    },
+    ...(bankingState.transactionHistory || [])
+  ].slice(0, 100);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+
+  if (portfolioKey === 'city') {
+    financeState.cityBudget = {
+      ...financeState.cityBudget,
+      total: (financeState.cityBudget.total || 0) + netAmount
+    };
+    budget += netAmount;
+  } else {
+    const mappedAccount = PERSONAL_BANK_ACCOUNT_MAP[accountType];
+    if (mappedAccount) {
+      const current = financeState.personalFinances?.accounts?.[mappedAccount] || 0;
+      financeState.personalFinances = {
+        ...financeState.personalFinances,
+        accounts: {
+          ...financeState.personalFinances.accounts,
+          [mappedAccount]: current + netAmount
+        }
+      };
+    }
+  }
+
+  return {
+    ...state,
+    errorMessage: null,
+    bankingState,
+    financeState,
+    budget,
+    personalFinances: buildPersonalFinancesSnapshot(financeState.personalFinances)
+  };
+};
+
+const appendTransaction = (history = [], entry) => [entry, ...history].slice(0, 100);
+
+const isCityAccount = (accountType) => accountType?.startsWith('city');
+
+const applyBankAccountChange = (financeStateInput, accountType, delta, currentBudget = 0) => {
+  const financeState = financeStateInput ? deepClone(financeStateInput) : deepClone(initialFinanceState);
+  let budget = currentBudget ?? 0;
+
+  if (!accountType) {
+    return {
+      financeState,
+      budget,
+      personalFinances: buildPersonalFinancesSnapshot(financeState.personalFinances)
+    };
+  }
+
+  if (isCityAccount(accountType)) {
+    const total = (financeState.cityBudget.total || 0) + delta;
+
+    financeState.cityBudget = {
+      ...financeState.cityBudget,
+      total: total < 0 ? 0 : total
+    };
+
+    budget = (budget || 0) + delta;
+    if (budget < 0) budget = 0;
+  } else {
+    const mappedAccount = PERSONAL_BANK_ACCOUNT_MAP[accountType] || PersonalAccountTypes.CHECKING;
+    const current = financeState.personalFinances?.accounts?.[mappedAccount] || 0;
+
+    financeState.personalFinances = {
+      ...financeState.personalFinances,
+      accounts: {
+        ...financeState.personalFinances.accounts,
+        [mappedAccount]: Math.max(0, current + delta)
+      }
+    };
+  }
+
+  return {
+    financeState,
+    budget,
+    personalFinances: buildPersonalFinancesSnapshot(financeState.personalFinances)
+  };
+};
+
+const adjustBankAccountBalance = (bankingStateInput, accountType, delta) => {
+  const bankingState = bankingStateInput ? deepClone(bankingStateInput) : deepClone(initialBankingState);
+
+  if (!accountType || !bankingState.accounts?.[accountType]) {
+    return bankingState;
+  }
+
+  const account = bankingState.accounts[accountType];
+  bankingState.accounts[accountType] = {
+    ...account,
+    balance: Math.max(0, (account.balance || 0) + delta)
+  };
+
+  return bankingState;
+};
+
+const handleTransferFunds = (state, payload = {}) => {
+  const { fromAccount, toAccount, amount } = payload;
+
+  if (!fromAccount || !toAccount || fromAccount === toAccount || !amount || amount <= 0) {
+    return { ...state, errorMessage: 'Некорректные параметры перевода' };
+  }
+
+  const bankingState = deepClone(state.bankingState || initialBankingState);
+  const from = bankingState.accounts?.[fromAccount];
+  const to = bankingState.accounts?.[toAccount];
+
+  if (!from || !to) {
+    return { ...state, errorMessage: 'Выбранный счет недоступен' };
+  }
+
+  if ((from.balance || 0) < amount) {
+    return { ...state, errorMessage: 'Недостаточно средств для перевода' };
+  }
+
+  bankingState.accounts[fromAccount] = {
+    ...from,
+    balance: from.balance - amount
+  };
+
+  bankingState.accounts[toAccount] = {
+    ...to,
+    balance: (to.balance || 0) + amount
+  };
+
+  bankingState.transactionHistory = appendTransaction(bankingState.transactionHistory, {
+    id: Date.now(),
+    type: 'transfer',
+    fromAccount,
+    toAccount,
+    amount,
+    timestamp: Date.now()
+  });
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances = buildPersonalFinancesSnapshot(financeState.personalFinances);
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(financeState, fromAccount, -amount, budget));
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(financeState, toAccount, amount, budget));
+
+  return {
+    ...state,
+    errorMessage: null,
+    bankingState,
+    financeState,
+    budget,
+    personalFinances
+  };
+};
+
+const resolveLoanAccount = (loan) => {
+  if (!loan) return BankAccountTypes.CITY_CHECKING;
+
+  if (loan.type === LoanTypes.PERSONAL) {
+    return BankAccountTypes.PERSONAL_CHECKING;
+  }
+
+  if (loan.type === LoanTypes.BUSINESS) {
+    return BankAccountTypes.PERSONAL_CHECKING;
+  }
+
+  return BankAccountTypes.CITY_CHECKING;
+};
+
+const handleTakeLoan = (state, payload = {}) => {
+  const { loanId } = payload;
+  const loanOffer = loanOffers.find((loan) => loan.id === loanId);
+
+  if (!loanOffer) {
+    return { ...state, errorMessage: 'Кредитное предложение не найдено' };
+  }
+
+  const creditRating = bankingHelpers.checkCreditRating(state);
+  if (loanOffer.requirements?.minRating && creditRating < loanOffer.requirements.minRating) {
+    return { ...state, errorMessage: 'Недостаточный кредитный рейтинг для данного кредита' };
+  }
+
+  const accountType = resolveLoanAccount(loanOffer);
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const account = bankingState.accounts?.[accountType];
+
+  if (!account) {
+    return { ...state, errorMessage: 'Счет для зачисления кредита недоступен' };
+  }
+
+  const updatedBankingState = adjustBankAccountBalance(bankingState, accountType, loanOffer.amount);
+  const monthlyPayment = bankingHelpers.calculateLoanPayment(loanOffer.amount, loanOffer.interestRate, loanOffer.term);
+
+  const loanEntry = {
+    id: `${loanOffer.id}_${Date.now()}`,
+    offerId: loanOffer.id,
+    type: loanOffer.type,
+    bank: loanOffer.bank,
+    amount: loanOffer.amount,
+    interestRate: loanOffer.interestRate,
+    term: loanOffer.term,
+    remainingAmount: loanOffer.amount,
+    remainingMonths: loanOffer.term,
+    issueDate: Date.now(),
+    monthlyPayment,
+    status: 'active',
+    accountType,
+    isPersonal: !isCityAccount(accountType)
+  };
+
+  updatedBankingState.loans = [loanEntry, ...(updatedBankingState.loans || [])];
+  updatedBankingState.transactionHistory = appendTransaction(updatedBankingState.transactionHistory, {
+    id: Date.now(),
+    type: 'loan_taken',
+    loanId: loanOffer.id,
+    amount: loanOffer.amount,
+    bank: loanOffer.bank,
+    accountType,
+    timestamp: Date.now()
+  });
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(financeState, accountType, loanOffer.amount, budget));
+
+  return {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances
+  };
+};
+
+const resolveDepositAccount = (depositId) => {
+  if (!depositId) return BankAccountTypes.CITY_CHECKING;
+  if (depositId.includes('personal')) return BankAccountTypes.PERSONAL_SAVINGS;
+  if (depositId.includes('offshore')) return BankAccountTypes.OFFSHORE;
+  if (depositId.includes('city')) return BankAccountTypes.CITY_SAVINGS;
+  return BankAccountTypes.CITY_CHECKING;
+};
+
+const handleCreateDeposit = (state, payload = {}) => {
+  const { depositId, amount } = payload;
+  const depositOffer = depositOffers.find((deposit) => deposit.id === depositId);
+
+  const depositAmount = Number(amount || 0);
+
+  if (!depositOffer) {
+    return { ...state, errorMessage: 'Депозит не найден' };
+  }
+
+  if (!depositAmount || depositAmount < depositOffer.minAmount) {
+    return { ...state, errorMessage: `Минимальная сумма для депозита: ${depositOffer.minAmount.toLocaleString('ru-RU')} ₽` };
+  }
+
+  if (depositOffer.maxAmount && depositAmount > depositOffer.maxAmount) {
+    return { ...state, errorMessage: `Максимальная сумма для депозита: ${depositOffer.maxAmount.toLocaleString('ru-RU')} ₽` };
+  }
+
+  const accountType = resolveDepositAccount(depositOffer.id);
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const account = bankingState.accounts?.[accountType];
+
+  if (!account || (account.balance || 0) < depositAmount) {
+    return { ...state, errorMessage: 'Недостаточно средств для открытия депозита' };
+  }
+
+  const updatedBankingState = adjustBankAccountBalance(bankingState, accountType, -depositAmount);
+  const depositEntry = {
+    id: `${depositOffer.id}_${Date.now()}`,
+    offerId: depositOffer.id,
+    bank: depositOffer.bank,
+    interestRate: depositOffer.interestRate,
+    term: depositOffer.term,
+    amount: depositAmount,
+    startDate: Date.now(),
+    maturityDate: Date.now() + depositOffer.term * 30 * 24 * 60 * 60 * 1000,
+    accruedInterest: 0,
+    accountType,
+    type: depositOffer.type,
+    remainingMonths: depositOffer.term
+  };
+
+  updatedBankingState.deposits = [depositEntry, ...(updatedBankingState.deposits || [])];
+  updatedBankingState.transactionHistory = appendTransaction(updatedBankingState.transactionHistory, {
+    id: Date.now(),
+    type: 'deposit_opened',
+    depositId: depositOffer.id,
+    amount: depositAmount,
+    bank: depositOffer.bank,
+    accountType,
+    timestamp: Date.now()
+  });
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(financeState, accountType, -depositAmount, budget));
+
+  return {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances
+  };
+};
+
+const POSITION_ORDER = [
+  PositionLevels.ASSISTANT,
+  PositionLevels.SPECIALIST,
+  PositionLevels.DEPARTMENT_HEAD,
+  PositionLevels.DEPUTY,
+  PositionLevels.HEAD
+];
+
+const findGovernmentEmployee = (governmentState, employeeId) => {
+  if (!governmentState?.employees) return null;
+
+  for (const [department, employees] of Object.entries(governmentState.employees)) {
+    const index = employees.findIndex((emp) => emp.id === employeeId);
+    if (index !== -1) {
+      return { department, index, employee: employees[index] };
+    }
+  }
+
+  return null;
+};
+
+const handlePromoteEmployee = (state, payload = {}) => {
+  const { employeeId } = payload;
+  const governmentState = state.governmentState ? deepClone(state.governmentState) : deepClone(initialGovernmentState);
+  const found = findGovernmentEmployee(governmentState, employeeId);
+
+  if (!found) {
+    return { ...state, errorMessage: 'Сотрудник не найден' };
+  }
+
+  const { department, index, employee } = found;
+  const currentLevelIndex = POSITION_ORDER.indexOf(employee.level);
+
+  if (currentLevelIndex === -1 || currentLevelIndex >= POSITION_ORDER.length - 1) {
+    return { ...state, errorMessage: 'Повышение невозможно' };
+  }
+
+  const newLevel = POSITION_ORDER[currentLevelIndex + 1];
+  const salaryIncrease = Math.round(employee.salary * 0.2);
+
+  const promotedEmployee = {
+    ...employee,
+    level: newLevel,
+    salary: employee.salary + salaryIncrease,
+    mood: clamp((employee.mood || 70) + 10),
+    workload: clamp((employee.workload || 70) - 10),
+    lastPromotion: new Date().toISOString()
+  };
+
+  governmentState.employees[department] = [...governmentState.employees[department]];
+  governmentState.employees[department][index] = promotedEmployee;
+
+  governmentState.performanceMetrics = {
+    ...governmentState.performanceMetrics,
+    decisionsPerMonth: (governmentState.performanceMetrics?.decisionsPerMonth || 0) + 1,
+    employeeSatisfaction: clamp((governmentState.performanceMetrics?.employeeSatisfaction || 70) + 2),
+    departmentEfficiency: clamp((governmentState.performanceMetrics?.departmentEfficiency || 70) + 1)
+  };
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  const adminExpenses = financeState.cityBudget?.monthlyExpenses?.[BudgetCategories.ADMINISTRATION] || 0;
+  financeState.cityBudget = {
+    ...financeState.cityBudget,
+    monthlyExpenses: {
+      ...financeState.cityBudget.monthlyExpenses,
+      [BudgetCategories.ADMINISTRATION]: Math.max(0, adminExpenses + salaryIncrease)
+    }
+  };
+
+  return {
+    ...state,
+    errorMessage: null,
+    mayorRating: clamp((state.mayorRating || 0) + 2, GameConstants.MIN_MAYOR_RATING, GameConstants.MAX_MAYOR_RATING),
+    governmentState,
+    financeState
+  };
+};
+
+const handleFireEmployee = (state, payload = {}) => {
+  const { employeeId } = payload;
+  const governmentState = state.governmentState ? deepClone(state.governmentState) : deepClone(initialGovernmentState);
+  const found = findGovernmentEmployee(governmentState, employeeId);
+
+  if (!found) {
+    return { ...state, errorMessage: 'Сотрудник не найден' };
+  }
+
+  const { department, index, employee } = found;
+  governmentState.employees[department] = governmentState.employees[department]
+    .filter((_, empIndex) => empIndex !== index);
+
+  governmentState.performanceMetrics = {
+    ...governmentState.performanceMetrics,
+    employeeSatisfaction: clamp((governmentState.performanceMetrics?.employeeSatisfaction || 70) - 5),
+    corruptionIncidents: (governmentState.performanceMetrics?.corruptionIncidents || 0) + 1
+  };
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  const adminExpenses = financeState.cityBudget?.monthlyExpenses?.[BudgetCategories.ADMINISTRATION] || 0;
+  financeState.cityBudget = {
+    ...financeState.cityBudget,
+    monthlyExpenses: {
+      ...financeState.cityBudget.monthlyExpenses,
+      [BudgetCategories.ADMINISTRATION]: Math.max(0, adminExpenses - employee.salary)
+    }
+  };
+
+  return {
+    ...state,
+    errorMessage: null,
+    mayorRating: clamp((state.mayorRating || 0) - 3, GameConstants.MIN_MAYOR_RATING, GameConstants.MAX_MAYOR_RATING),
+    governmentState,
+    financeState
+  };
+};
+
+const handleChangeEmployeeSalary = (state, payload = {}) => {
+  const { employeeId, salary } = payload;
+  const newSalary = Number(salary);
+
+  if (!newSalary || newSalary <= 0) {
+    return { ...state, errorMessage: 'Некорректная зарплата' };
+  }
+
+  const governmentState = state.governmentState ? deepClone(state.governmentState) : deepClone(initialGovernmentState);
+  const found = findGovernmentEmployee(governmentState, employeeId);
+
+  if (!found) {
+    return { ...state, errorMessage: 'Сотрудник не найден' };
+  }
+
+  const { department, index, employee } = found;
+  const salaryDelta = newSalary - employee.salary;
+
+  const updatedEmployee = {
+    ...employee,
+    salary: newSalary,
+    mood: clamp((employee.mood || 70) + (salaryDelta > 0 ? 5 : -5))
+  };
+
+  governmentState.employees[department] = [...governmentState.employees[department]];
+  governmentState.employees[department][index] = updatedEmployee;
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  const adminExpenses = financeState.cityBudget?.monthlyExpenses?.[BudgetCategories.ADMINISTRATION] || 0;
+  financeState.cityBudget = {
+    ...financeState.cityBudget,
+    monthlyExpenses: {
+      ...financeState.cityBudget.monthlyExpenses,
+      [BudgetCategories.ADMINISTRATION]: Math.max(0, adminExpenses + salaryDelta)
+    }
+  };
+
+  return {
+    ...state,
+    errorMessage: null,
+    governmentState,
+    financeState
+  };
+};
+
+const handleImplementPolicy = (state, payload = {}) => {
+  const { policyId } = payload;
+  const policy = policyOptions.find((option) => option.id === policyId);
+
+  if (!policy) {
+    return { ...state, errorMessage: 'Политика не найдена' };
+  }
+
+  const governmentState = state.governmentState ? deepClone(state.governmentState) : deepClone(initialGovernmentState);
+  if (governmentState.activePolicies?.some((active) => active.policyId === policy.id)) {
+    return { ...state, errorMessage: 'Политика уже активна' };
+  }
+
+  const departmentEmployees = governmentState.employees?.[policy.department] || [];
+  const canImplement = governmentHelpers.canImplementPolicy(policy, policy.department, departmentEmployees);
+  if (!canImplement.canImplement) {
+    return { ...state, errorMessage: canImplement.reason };
+  }
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+  if (!cityAccount || (cityAccount.balance || 0) < policy.cost) {
+    return { ...state, errorMessage: 'Недостаточно средств для реализации политики' };
+  }
+
+  const updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -policy.cost);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(financeState, BankAccountTypes.CITY_CHECKING, -policy.cost, budget));
+
+  const policyEntry = {
+    id: `${policy.id}_${Date.now()}`,
+    policyId: policy.id,
+    startDate: Date.now(),
+    remainingDuration: policy.duration || 0,
+    effects: policy.effects
+  };
+
+  governmentState.activePolicies = [policyEntry, ...(governmentState.activePolicies || [])];
+  governmentState.performanceMetrics = {
+    ...governmentState.performanceMetrics,
+    decisionsPerMonth: (governmentState.performanceMetrics?.decisionsPerMonth || 0) + 1,
+    departmentEfficiency: clamp((governmentState.performanceMetrics?.departmentEfficiency || 70) + (policy.effects?.efficiency || 0))
+  };
+
+  if (policy.effects?.employeeMood) {
+    governmentState.employees[policy.department] = (governmentState.employees[policy.department] || []).map((emp) => ({
+      ...emp,
+      mood: clamp((emp.mood || 70) + policy.effects.employeeMood)
+    }));
+  }
+
+  if (policy.effects?.corruptionRisk && financeState.risks) {
+    financeState.risks = {
+      ...financeState.risks,
+      publicSuspicion: clamp((financeState.risks.publicSuspicion || 0) + policy.effects.corruptionRisk),
+      investigationRisk: clamp((financeState.risks.investigationRisk || 0) + policy.effects.corruptionRisk)
+    };
+  }
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    governmentState
+  };
+
+  if (policy.effects?.mayorRating) {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) + policy.effects.mayorRating,
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  }
+
+  if (policy.effects?.happiness) {
+    updatedState.happiness = clamp((state.happiness || 0) + policy.effects.happiness);
+  }
+
+  if (policy.effects?.infrastructure) {
+    updatedState.infrastructure = clamp((state.infrastructure || 0) + policy.effects.infrastructure);
+  }
+
+  if (policy.effects?.unemployment) {
+    updatedState.unemployment = Math.max(0, (state.unemployment || 0) + policy.effects.unemployment);
+  }
+
+  return updatedState;
+};
+
+const handleMakeGovernmentDecision = (state, payload = {}) => {
+  const { decisionType, data = {} } = payload;
+  const governmentState = state.governmentState ? deepClone(state.governmentState) : deepClone(initialGovernmentState);
+
+  const decisionRecord = {
+    id: Date.now(),
+    type: decisionType,
+    data,
+    timestamp: Date.now()
+  };
+
+  governmentState.pendingDecisions = [decisionRecord, ...(governmentState.pendingDecisions || [])].slice(0, 20);
+  governmentState.performanceMetrics = {
+    ...governmentState.performanceMetrics,
+    decisionsPerMonth: (governmentState.performanceMetrics?.decisionsPerMonth || 0) + 1
+  };
+
+  let bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances = state.personalFinances || buildPersonalFinancesSnapshot(financeState.personalFinances);
+
+  if (data.budgetChange) {
+    const budgetChange = Number(data.budgetChange);
+    if (!Number.isNaN(budgetChange) && budgetChange !== 0) {
+      bankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, budgetChange);
+      ({ financeState, budget, personalFinances } = applyBankAccountChange(
+        financeState,
+        BankAccountTypes.CITY_CHECKING,
+        budgetChange,
+        budget
+      ));
+    }
+  }
+
+  if (data.department && governmentState.departmentSettings?.[data.department]) {
+    governmentState.departmentSettings[data.department] = {
+      ...governmentState.departmentSettings[data.department],
+      ...data.departmentUpdate
+    };
+  }
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState,
+    financeState,
+    budget,
+    personalFinances,
+    governmentState
+  };
+
+  if (data.ratingChange) {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) + data.ratingChange,
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  }
+
+  return updatedState;
+};
+
+const handleMakeInvestment = (state, payload = {}) => {
+  const { investmentId, amount } = payload;
+  const investment = investmentOpportunities.find((item) => item.id === investmentId);
+  const investmentAmount = Number(amount || 0);
+
+  if (!investment) {
+    return { ...state, errorMessage: 'Инвестиционное предложение не найдено' };
+  }
+
+  if (!investmentAmount || investmentAmount <= 0) {
+    return { ...state, errorMessage: 'Некорректная сумма инвестиций' };
+  }
+
+  const canInvest = investmentHelpers.canInvest(investment, investmentAmount, state);
+  if (!canInvest.canInvest) {
+    return { ...state, errorMessage: canInvest.reason };
+  }
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+  if (!cityAccount || (cityAccount.balance || 0) < investmentAmount) {
+    return { ...state, errorMessage: 'Недостаточно средств для инвестиций' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -investmentAmount);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.CITY_CHECKING,
+    -investmentAmount,
+    budget
+  ));
+
+  let kickbackAmount = 0;
+  if (investment.personalBenefits?.kickbackPercent) {
+    kickbackAmount = Math.round(investmentAmount * investment.personalBenefits.kickbackPercent / 100);
+  }
+
+  if (investment.personalBenefits?.personalProperty) {
+    kickbackAmount += investment.personalBenefits.personalProperty;
+  }
+
+  if (kickbackAmount > 0) {
+    updatedBankingState = adjustBankAccountBalance(updatedBankingState, BankAccountTypes.PERSONAL_SAVINGS, kickbackAmount);
+    ({ financeState, budget, personalFinances } = applyBankAccountChange(
+      financeState,
+      BankAccountTypes.PERSONAL_SAVINGS,
+      kickbackAmount,
+      budget
+    ));
+  }
+
+  const investmentState = state.investmentState ? deepClone(state.investmentState) : deepClone(initialInvestmentState);
+
+  const existingActive = investmentState.activeInvestments?.filter((inv) => inv.id !== investment.id) || [];
+  const newInvestment = {
+    id: investment.id,
+    amount: investmentAmount,
+    startDate: Date.now(),
+    monthsPassed: 0,
+    expectedReturn: investment.expectedReturn,
+    riskLevel: investment.riskLevel,
+    sector: investment.sector,
+    status: 'active'
+  };
+
+  investmentState.activeInvestments = [newInvestment, ...existingActive];
+  investmentState.portfolio = {
+    ...investmentState.portfolio,
+    totalInvested: (investmentState.portfolio?.totalInvested || 0) + investmentAmount,
+    activeValue: (investmentState.portfolio?.activeValue || 0) + investmentAmount,
+    sectorDistribution: {
+      ...(investmentState.portfolio?.sectorDistribution || {}),
+      [investment.sector]: ((investmentState.portfolio?.sectorDistribution || {})[investment.sector] || 0) + investmentAmount
+    }
+  };
+
+  const riskScore = investmentHelpers.calculateInvestmentRisk(investment, state);
+  investmentState.investmentMetrics = {
+    ...investmentState.investmentMetrics,
+    totalProjects: (investmentState.investmentMetrics?.totalProjects || 0) + 1,
+    riskScore: Math.round((investmentState.investmentMetrics?.riskScore || 0) * 0.7 + riskScore * 0.3),
+    averageReturn: Math.round(((investmentState.investmentMetrics?.averageReturn || 0) + investment.expectedReturn) / 2)
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    investmentState
+  };
+
+  if (investment.cityBenefits?.mayorRating) {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) + Math.round(investment.cityBenefits.mayorRating * 0.2),
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  }
+
+  return updatedState;
+};
+
+const handleWithdrawInvestment = (state, payload = {}) => {
+  const { investmentId, amount } = payload;
+  const investmentState = state.investmentState ? deepClone(state.investmentState) : deepClone(initialInvestmentState);
+  const activeInvestment = investmentState.activeInvestments?.find((inv) => inv.id === investmentId);
+  const investment = investmentOpportunities.find((item) => item.id === investmentId);
+
+  if (!activeInvestment || !investment) {
+    return { ...state, errorMessage: 'Активная инвестиция не найдена' };
+  }
+
+  const withdrawAmount = Number(amount || activeInvestment.amount);
+  if (!withdrawAmount || withdrawAmount <= 0) {
+    return { ...state, errorMessage: 'Некорректная сумма вывода' };
+  }
+
+  const currentValue = investmentHelpers.calculateCurrentValue(
+    investment,
+    activeInvestment.monthsPassed || 0,
+    activeInvestment.amount
+  );
+
+  const payout = Math.min(currentValue, withdrawAmount + Math.max(0, currentValue - activeInvestment.amount));
+  let bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  bankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, payout);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.CITY_CHECKING,
+    payout,
+    budget
+  ));
+
+  const profit = payout - activeInvestment.amount;
+  investmentState.activeInvestments = investmentState.activeInvestments.filter((inv) => inv.id !== investmentId);
+  investmentState.completedInvestments = [
+    {
+      id: `${investmentId}_${Date.now()}`,
+      investmentId,
+      amount: activeInvestment.amount,
+      returned: payout,
+      profit,
+      completedAt: Date.now()
+    },
+    ...(investmentState.completedInvestments || [])
+  ];
+
+  investmentState.portfolio = {
+    ...investmentState.portfolio,
+    totalInvested: Math.max(0, (investmentState.portfolio?.totalInvested || 0) - activeInvestment.amount),
+    activeValue: Math.max(0, (investmentState.portfolio?.activeValue || 0) - activeInvestment.amount),
+    totalReturns: (investmentState.portfolio?.totalReturns || 0) + Math.max(0, profit),
+    sectorDistribution: {
+      ...(investmentState.portfolio?.sectorDistribution || {}),
+      [investment.sector]: Math.max(
+        0,
+        ((investmentState.portfolio?.sectorDistribution || {})[investment.sector] || 0) - activeInvestment.amount
+      )
+    }
+  };
+
+  if (investment.cityBenefits?.taxRevenue) {
+    const monthlyIncome = financeState.cityBudget?.monthlyIncome?.[IncomeTypes.BUSINESS_TAXES] || 0;
+    financeState.cityBudget = {
+      ...financeState.cityBudget,
+      monthlyIncome: {
+        ...financeState.cityBudget.monthlyIncome,
+        [IncomeTypes.BUSINESS_TAXES]: monthlyIncome + Math.round(investment.cityBenefits.taxRevenue / 12)
+      }
+    };
+  }
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState,
+    financeState,
+    budget,
+    personalFinances,
+    investmentState
+  };
+
+  if (investment.cityBenefits?.mayorRating) {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) + investment.cityBenefits.mayorRating,
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  }
+
+  if (investment.cityBenefits?.happiness) {
+    updatedState.happiness = clamp((state.happiness || 0) + investment.cityBenefits.happiness);
+  }
+
+  if (investment.cityBenefits?.infrastructure) {
+    updatedState.infrastructure = clamp((state.infrastructure || 0) + investment.cityBenefits.infrastructure);
+  }
+
+  if (investment.cityBenefits?.unemployment) {
+    updatedState.unemployment = Math.max(0, (state.unemployment || 0) + investment.cityBenefits.unemployment);
+  }
+
+  if (investment.personalBenefits?.personalShares) {
+    const personalBonus = Math.round(payout * (investment.personalBenefits.personalShares / 100));
+    if (personalBonus > 0) {
+      updatedState.bankingState = adjustBankAccountBalance(updatedState.bankingState, BankAccountTypes.PERSONAL_SAVINGS, personalBonus);
+      ({ financeState: updatedState.financeState, budget: updatedState.budget, personalFinances: updatedState.personalFinances } = applyBankAccountChange(
+        updatedState.financeState,
+        BankAccountTypes.PERSONAL_SAVINGS,
+        personalBonus,
+        updatedState.budget
+      ));
+    }
+  }
+
+  return updatedState;
+};
+
+const handleImplementIndustrialProject = (state, payload = {}) => {
+  const { projectId, kickbacks = [] } = payload;
+  const project = industrialProjects.find((item) => item.id === projectId);
+
+  if (!project) {
+    return { ...state, errorMessage: 'Промышленный проект не найден' };
+  }
+
+  const canImplement = industryHelpers.canImplementProject(project, state);
+  if (!canImplement.canImplement) {
+    return { ...state, errorMessage: canImplement.reason };
+  }
+
+  const kickbackTotal = kickbacks.reduce((sum, item) => sum + (item.amount || 0), 0);
+  const totalCost = project.totalCost + kickbackTotal;
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+  if (!cityAccount || (cityAccount.balance || 0) < totalCost) {
+    return { ...state, errorMessage: 'Недостаточно средств для реализации проекта' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -totalCost);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.CITY_CHECKING,
+    -totalCost,
+    budget
+  ));
+
+  if (kickbackTotal > 0) {
+    updatedBankingState = adjustBankAccountBalance(updatedBankingState, BankAccountTypes.OFFSHORE, kickbackTotal);
+    ({ financeState, budget, personalFinances } = applyBankAccountChange(
+      financeState,
+      BankAccountTypes.OFFSHORE,
+      kickbackTotal,
+      budget
+    ));
+  }
+
+  const industryState = state.industryState ? deepClone(state.industryState) : deepClone(initialIndustryState);
+  const activeProject = {
+    id: project.id,
+    startDate: Date.now(),
+    monthsPassed: 0,
+    status: ProjectStatus.CONSTRUCTION,
+    kickbacksSelected: kickbacks.map((item) => item.type),
+    kickbacksReceived: kickbackTotal,
+    totalCost: project.totalCost
+  };
+
+  industryState.activeProjects = [activeProject, ...(industryState.activeProjects || [])];
+  industryState.kickbacks = {
+    ...industryState.kickbacks,
+    total: (industryState.kickbacks?.total || 0) + kickbackTotal,
+    byType: kickbacks.reduce((acc, item) => ({
+      ...acc,
+      [item.type]: (industryState.kickbacks?.byType?.[item.type] || 0) + (item.amount || 0)
+    }), { ...(industryState.kickbacks?.byType || {}) }),
+    byProject: {
+      ...(industryState.kickbacks?.byProject || {}),
+      [project.id]: ((industryState.kickbacks?.byProject || {})[project.id] || 0) + kickbackTotal
+    },
+    history: [
+      {
+        id: Date.now(),
+        projectId: project.id,
+        amount: kickbackTotal,
+        types: kickbacks.map((item) => item.type),
+        timestamp: Date.now()
+      },
+      ...((industryState.kickbacks?.history || []).slice(0, 49))
+    ]
+  };
+
+  industryState.industryMetrics = {
+    ...industryState.industryMetrics,
+    totalInvestment: (industryState.industryMetrics?.totalInvestment || 0) + project.totalCost,
+    industrialCapacity: clamp((industryState.industryMetrics?.industrialCapacity || 0) + (project.benefits?.industrialCapacity || 0))
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    industryState
+  };
+
+  if (project.benefits?.mayorRating) {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) + Math.round(project.benefits.mayorRating * 0.3),
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  }
+
+  return updatedState;
+};
+
+const handleModernizeEnterprise = (state, payload = {}) => {
+  const { enterpriseId } = payload;
+  const industryState = state.industryState ? deepClone(state.industryState) : deepClone(initialIndustryState);
+  const enterpriseIndex = industryState.enterprises?.findIndex((item) => item.id === enterpriseId) ?? -1;
+
+  if (enterpriseIndex === -1) {
+    return { ...state, errorMessage: 'Предприятие не найдено' };
+  }
+
+  const enterprise = industryState.enterprises[enterpriseIndex];
+  if (!enterprise.modernizationNeeded) {
+    return { ...state, errorMessage: 'Предприятие не требует модернизации' };
+  }
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+  if (!cityAccount || (cityAccount.balance || 0) < enterprise.modernizationCost) {
+    return { ...state, errorMessage: 'Недостаточно средств для модернизации' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -enterprise.modernizationCost);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.CITY_CHECKING,
+    -enterprise.modernizationCost,
+    budget
+  ));
+
+  const modernizationKickback = Math.round(enterprise.modernizationCost * 0.05);
+  if (modernizationKickback > 0) {
+    updatedBankingState = adjustBankAccountBalance(updatedBankingState, BankAccountTypes.OFFSHORE, modernizationKickback);
+    ({ financeState, budget, personalFinances } = applyBankAccountChange(
+      financeState,
+      BankAccountTypes.OFFSHORE,
+      modernizationKickback,
+      budget
+    ));
+  }
+
+  const modernizedEnterprise = {
+    ...enterprise,
+    modernizationNeeded: false,
+    status: 'modernized',
+    employees: (enterprise.employees || 0) + (enterprise.modernizationBenefits?.jobs || 0),
+    annualRevenue: (enterprise.annualRevenue || 0) + (enterprise.modernizationBenefits?.revenue || 0),
+    taxContribution: (enterprise.taxContribution || 0) + Math.round((enterprise.modernizationBenefits?.revenue || 0) * 0.1)
+  };
+
+  industryState.enterprises = [...industryState.enterprises];
+  industryState.enterprises[enterpriseIndex] = modernizedEnterprise;
+  industryState.industryMetrics = {
+    ...industryState.industryMetrics,
+    totalEmployment: (industryState.industryMetrics?.totalEmployment || 0) + (enterprise.modernizationBenefits?.jobs || 0),
+    totalRevenue: (industryState.industryMetrics?.totalRevenue || 0) + (enterprise.modernizationBenefits?.revenue || 0),
+    totalTaxRevenue: (industryState.industryMetrics?.totalTaxRevenue || 0) + Math.round((enterprise.modernizationBenefits?.revenue || 0) * 0.1)
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    industryState
+  };
+
+  if (enterprise.modernizationBenefits?.efficiency) {
+    updatedState.infrastructure = clamp((state.infrastructure || 0) + enterprise.modernizationBenefits.efficiency);
+  }
+
+  if (enterprise.modernizationBenefits?.ecology) {
+    updatedState.ecology = clamp((state.ecology || 0) + enterprise.modernizationBenefits.ecology);
+  }
+
+  return updatedState;
+};
+
+const PERSONAL_OPERATION_TYPES = new Set([
+  OperationTypes.BRIBE,
+  OperationTypes.BLACKMAIL,
+  OperationTypes.FAVOR,
+  OperationTypes.CASE_DISMISSAL
+]);
+
+const handleExecuteSecurityOperation = (state, payload = {}) => {
+  const { agencyId, operation } = payload;
+
+  if (!agencyId || !operation) {
+    return { ...state, errorMessage: 'Некорректные параметры операции' };
+  }
+
+  const securityState = state.securityState ? deepClone(state.securityState) : deepClone(initialSecurityState);
+  const agency = securityState.agencies?.[agencyId];
+
+  if (!agency) {
+    return { ...state, errorMessage: 'Силовое ведомство не найдено' };
+  }
+
+  const cost = Number(operation.cost || 0);
+  const usePersonalFunds = PERSONAL_OPERATION_TYPES.has(operation.type);
+  const accountType = usePersonalFunds ? BankAccountTypes.PERSONAL_CHECKING : BankAccountTypes.CITY_CHECKING;
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const account = bankingState.accounts?.[accountType];
+  if (!account || (account.balance || 0) < cost) {
+    return { ...state, errorMessage: 'Недостаточно средств для проведения операции' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, accountType, -cost);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    accountType,
+    -cost,
+    budget
+  ));
+
+  const successRate = securityHelpers.calculateOperationSuccess(operation, agency, state);
+  const success = Math.random() * 100 < successRate;
+
+  const agencyEntry = {
+    ...agency,
+    lastInteraction: Date.now(),
+    totalBribes: (agency.totalBribes || 0) + (operation.type === OperationTypes.BRIBE ? cost : 0),
+    operationHistory: [
+      {
+        id: Date.now(),
+        type: operation.type,
+        cost,
+        success,
+        timestamp: Date.now()
+      },
+      ...((agency.operationHistory || []).slice(0, 19))
+    ]
+  };
+
+  if (success) {
+    const influenceOrder = [
+      InfluenceLevels.HOSTILE,
+      InfluenceLevels.UNFRIENDLY,
+      InfluenceLevels.NEUTRAL,
+      InfluenceLevels.FRIENDLY,
+      InfluenceLevels.CONTROLLED
+    ];
+    const currentIndex = influenceOrder.indexOf(agencyEntry.influence);
+    if (currentIndex < influenceOrder.length - 1 && currentIndex !== -1) {
+      agencyEntry.influence = influenceOrder[currentIndex + 1];
+    }
+  } else {
+    const influenceOrder = [
+      InfluenceLevels.CONTROLLED,
+      InfluenceLevels.FRIENDLY,
+      InfluenceLevels.NEUTRAL,
+      InfluenceLevels.UNFRIENDLY,
+      InfluenceLevels.HOSTILE
+    ];
+    const currentIndex = influenceOrder.indexOf(agencyEntry.influence);
+    if (currentIndex < influenceOrder.length - 1 && currentIndex !== -1) {
+      agencyEntry.influence = influenceOrder[currentIndex + 1];
+    }
+  }
+
+  securityState.agencies = {
+    ...securityState.agencies,
+    [agencyId]: agencyEntry
+  };
+
+  securityState.operationHistory = [
+    {
+      id: Date.now(),
+      agencyId,
+      type: operation.type,
+      cost,
+      success,
+      successRate,
+      timestamp: Date.now()
+    },
+    ...((securityState.operationHistory || []).slice(0, 49))
+  ];
+
+  securityState.securityMetrics = {
+    ...securityState.securityMetrics,
+    investigationProbability: clamp(
+      (securityState.securityMetrics?.investigationProbability || 0) + (success ? -5 : 5),
+      0,
+      100
+    ),
+    protectionLevel: clamp(
+      (securityState.securityMetrics?.protectionLevel || 0) + (success ? 5 : -2),
+      0,
+      100
+    )
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    securityState
+  };
+
+  if (!success && operation.type === OperationTypes.BRIBE) {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) - 3,
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  }
+
+  return updatedState;
+};
+
+const handleMitigateThreat = (state, payload = {}) => {
+  const { threatId, mitigationOption = {} } = payload;
+  const securityState = state.securityState ? deepClone(state.securityState) : deepClone(initialSecurityState);
+  const threatIndex = securityState.activeThreats?.findIndex((threat) => threat.id === threatId) ?? -1;
+
+  if (threatIndex === -1) {
+    return { ...state, errorMessage: 'Угроза не найдена' };
+  }
+
+  const threat = securityState.activeThreats[threatIndex];
+  const cost = Number(mitigationOption.cost || 0);
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+  if (!cityAccount || (cityAccount.balance || 0) < cost) {
+    return { ...state, errorMessage: 'Недостаточно средств для противодействия угрозе' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -cost);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.CITY_CHECKING,
+    -cost,
+    budget
+  ));
+
+  const successRate = mitigationOption.success_rate || 60;
+  const success = Math.random() * 100 < successRate;
+
+  if (success) {
+    securityState.activeThreats = securityState.activeThreats.filter((item, index) => index !== threatIndex);
+    securityState.securityMetrics = {
+      ...securityState.securityMetrics,
+      overallThreatLevel: ThreatLevels.LOW,
+      investigationProbability: clamp((securityState.securityMetrics?.investigationProbability || 0) - 10, 0, 100)
+    };
+  } else {
+    securityState.activeThreats[threatIndex] = {
+      ...threat,
+      escalation: true,
+      probability: Math.min(1, (threat.probability || 0) + 0.1)
+    };
+    securityState.securityMetrics = {
+      ...securityState.securityMetrics,
+      overallThreatLevel: ThreatLevels.HIGH
+    };
+  }
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    securityState
+  };
+
+  if (success) {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) + 2,
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  } else {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) - 2,
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  }
+
+  return updatedState;
+};
+
+const handleRespondToIssue = (state, payload = {}) => {
+  const { issueId, response = {} } = payload;
+  const citizensState = state.citizensState ? deepClone(state.citizensState) : deepClone(initialCitizensState);
+  const issueIndex = citizensState.activeIssues?.findIndex((issue) => issue.id === issueId) ?? -1;
+
+  if (issueIndex === -1) {
+    return { ...state, errorMessage: 'Обращение не найдено' };
+  }
+
+  const issue = citizensState.activeIssues[issueIndex];
+  const groupId = issue.group;
+  const group = citizensState.groups?.[groupId];
+
+  if (!group) {
+    return { ...state, errorMessage: 'Группа граждан не найдена' };
+  }
+
+  const amount = Number(response.amount || 0);
+  let bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances = state.personalFinances || buildPersonalFinancesSnapshot(financeState.personalFinances);
+
+  if (amount > 0) {
+    const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+    if (!cityAccount || (cityAccount.balance || 0) < amount) {
+      return { ...state, errorMessage: 'Недостаточно средств для ответа' };
+    }
+
+    bankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -amount);
+    ({ financeState, budget, personalFinances } = applyBankAccountChange(
+      financeState,
+      BankAccountTypes.CITY_CHECKING,
+      -amount,
+      budget
+    ));
+  }
+
+  const satisfactionChange = citizenHelpers.calculateSatisfactionChange(response, issue, group, state);
+  citizensState.groups[groupId] = {
+    ...group,
+    satisfaction: clamp((group.satisfaction || 0) + satisfactionChange)
+  };
+
+  const resolvedIssue = {
+    ...issue,
+    resolvedAt: Date.now(),
+    response
+  };
+
+  citizensState.activeIssues = citizensState.activeIssues.filter((item) => item.id !== issueId);
+  citizensState.resolvedIssues = [resolvedIssue, ...(citizensState.resolvedIssues || [])].slice(0, 50);
+
+  citizensState.communicationStats = {
+    ...citizensState.communicationStats,
+    totalIssues: (citizensState.communicationStats?.totalIssues || 0) + 1,
+    resolvedIssues: (citizensState.communicationStats?.resolvedIssues || 0) + 1,
+    satisfactionRate: clamp((citizensState.communicationStats?.satisfactionRate || 50) + Math.sign(satisfactionChange) * 5)
+  };
+
+  citizensState.citizenMetrics = {
+    ...citizensState.citizenMetrics,
+    overallSatisfaction: clamp(citizenHelpers.calculateOverallSatisfaction(citizensState.groups))
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    citizensState,
+    bankingState,
+    financeState,
+    budget,
+    personalFinances
+  };
+
+  updatedState.happiness = clamp((state.happiness || 0) + satisfactionChange * 0.2);
+  updatedState.mayorRating = clamp(
+    (state.mayorRating || 0) + Math.round(satisfactionChange * 0.3),
+    GameConstants.MIN_MAYOR_RATING,
+    GameConstants.MAX_MAYOR_RATING
+  );
+
+  return updatedState;
+};
+
+const handleScheduleMeeting = (state, payload = {}) => {
+  const { groupId } = payload;
+  const citizensState = state.citizensState ? deepClone(state.citizensState) : deepClone(initialCitizensState);
+  const group = citizensState.groups?.[groupId];
+
+  if (!group) {
+    return { ...state, errorMessage: 'Группа граждан не найдена' };
+  }
+
+  const updatedGroup = {
+    ...group,
+    lastInteraction: Date.now(),
+    satisfaction: clamp((group.satisfaction || 0) + 3),
+    communicationHistory: [
+      {
+        id: Date.now(),
+        type: 'meeting',
+        timestamp: Date.now()
+      },
+      ...((group.communicationHistory || []).slice(0, 19))
+    ]
+  };
+
+  citizensState.groups[groupId] = updatedGroup;
+  citizensState.citizenMetrics = {
+    ...citizensState.citizenMetrics,
+    participationRate: clamp((citizensState.citizenMetrics?.participationRate || 0) + 2)
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    citizensState
+  };
+
+  updatedState.happiness = clamp((state.happiness || 0) + 1);
+  updatedState.mayorRating = clamp(
+    (state.mayorRating || 0) + 1,
+    GameConstants.MIN_MAYOR_RATING,
+    GameConstants.MAX_MAYOR_RATING
+  );
+
+  return updatedState;
+};
+
+const TAX_INCOME_MAP = {
+  [TaxTypes.INCOME_TAX]: IncomeTypes.LOCAL_TAXES,
+  [TaxTypes.PROPERTY_TAX]: IncomeTypes.PROPERTY_TAXES,
+  [TaxTypes.LAND_TAX]: IncomeTypes.LOCAL_TAXES,
+  [TaxTypes.TRANSPORT_TAX]: IncomeTypes.FINES,
+  [TaxTypes.BUSINESS_TAX]: IncomeTypes.BUSINESS_TAXES,
+  [TaxTypes.SALES_TAX]: IncomeTypes.LOCAL_TAXES,
+  [TaxTypes.EXCISE_TAX]: IncomeTypes.FINES,
+  [TaxTypes.TOURIST_TAX]: IncomeTypes.INVESTMENTS,
+  [TaxTypes.ADVERTISING_TAX]: IncomeTypes.BUSINESS_TAXES,
+  [TaxTypes.ENVIRONMENTAL_TAX]: IncomeTypes.FINES
+};
+
+const EXPENDITURE_TO_BUDGET = {
+  [ExpenditureCategories.ADMINISTRATION]: BudgetCategories.ADMINISTRATION,
+  [ExpenditureCategories.EDUCATION]: BudgetCategories.EDUCATION,
+  [ExpenditureCategories.HEALTHCARE]: BudgetCategories.HEALTHCARE,
+  [ExpenditureCategories.SOCIAL_SERVICES]: BudgetCategories.SOCIAL,
+  [ExpenditureCategories.INFRASTRUCTURE]: BudgetCategories.INFRASTRUCTURE,
+  [ExpenditureCategories.TRANSPORT]: BudgetCategories.INFRASTRUCTURE,
+  [ExpenditureCategories.HOUSING_UTILITIES]: BudgetCategories.EMERGENCY,
+  [ExpenditureCategories.CULTURE_SPORTS]: BudgetCategories.CULTURE,
+  [ExpenditureCategories.ENVIRONMENT]: BudgetCategories.ECOLOGY,
+  [ExpenditureCategories.SECURITY]: BudgetCategories.SECURITY,
+  [ExpenditureCategories.RESERVES]: BudgetCategories.EMERGENCY
+};
+
+const handleImplementTaxPolicy = (state, payload = {}) => {
+  const { policyId } = payload;
+  const policy = taxPolicies.find((item) => item.id === policyId);
+
+  if (!policy) {
+    return { ...state, errorMessage: 'Налоговая политика не найдена' };
+  }
+
+  const taxationState = state.taxationState ? deepClone(state.taxationState) : deepClone(initialTaxationState);
+  if (taxationState.activePolicies?.some((active) => active.policyId === policy.id)) {
+    return { ...state, errorMessage: 'Политика уже активна' };
+  }
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+  if (!cityAccount || (cityAccount.balance || 0) < policy.cost) {
+    return { ...state, errorMessage: 'Недостаточно средств для реализации налоговой политики' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -policy.cost);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.CITY_CHECKING,
+    -policy.cost,
+    budget
+  ));
+
+  const policyEntry = {
+    id: `${policy.id}_${Date.now()}`,
+    policyId: policy.id,
+    startDate: Date.now(),
+    remainingDuration: policy.implementation_time || 0,
+    effects: policy.consequences || {}
+  };
+
+  taxationState.activePolicies = [policyEntry, ...(taxationState.activePolicies || [])];
+  taxationState.policyHistory = [
+    {
+      id: policyEntry.id,
+      policyId: policy.id,
+      timestamp: Date.now()
+    },
+    ...(taxationState.policyHistory || [])
+  ];
+
+  if (policy.consequences?.revenue_change) {
+    const revenueChange = policy.consequences.revenue_change;
+    taxationState.taxMetrics = {
+      ...taxationState.taxMetrics,
+      totalRevenue: (taxationState.taxMetrics?.totalRevenue || 0) + revenueChange
+    };
+    taxationState.revenueStructure = {
+      ...taxationState.revenueStructure,
+      [RevenueCategories.LOCAL_TAXES]: {
+        ...(taxationState.revenueStructure?.[RevenueCategories.LOCAL_TAXES] || {}),
+        amount: (taxationState.revenueStructure?.[RevenueCategories.LOCAL_TAXES]?.amount || 0) + revenueChange
+      }
+    };
+
+    const monthlyIncrease = Math.round(revenueChange / 12);
+    financeState.cityBudget = {
+      ...financeState.cityBudget,
+      monthlyIncome: {
+        ...financeState.cityBudget.monthlyIncome,
+        [IncomeTypes.LOCAL_TAXES]: (financeState.cityBudget.monthlyIncome?.[IncomeTypes.LOCAL_TAXES] || 0) + monthlyIncrease
+      }
+    };
+  }
+
+  if (policy.consequences?.citizen_satisfaction && state.citizensState) {
+    const citizensState = state.citizensState ? deepClone(state.citizensState) : deepClone(initialCitizensState);
+    Object.entries(policy.consequences.citizen_satisfaction).forEach(([groupKey, change]) => {
+      const key = Object.keys(citizensState.groups).find((id) => id.includes(groupKey));
+      if (key && citizensState.groups[key]) {
+        citizensState.groups[key] = {
+          ...citizensState.groups[key],
+          satisfaction: clamp((citizensState.groups[key].satisfaction || 0) + change)
+        };
+      }
+    });
+
+    return {
+      ...state,
+      errorMessage: null,
+      bankingState: updatedBankingState,
+      financeState,
+      budget,
+      personalFinances,
+      taxationState,
+      citizensState
+    };
+  }
+
+  return {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    taxationState
+  };
+};
+
+const handleChangeTaxRate = (state, payload = {}) => {
+  const { taxType, newRate } = payload;
+  if (!taxType || newRate === undefined) {
+    return { ...state, errorMessage: 'Некорректные параметры изменения ставки' };
+  }
+
+  const taxationState = state.taxationState ? deepClone(state.taxationState) : deepClone(initialTaxationState);
+  const currentRate = taxationState.currentRates?.[taxType];
+
+  if (currentRate === undefined) {
+    return { ...state, errorMessage: 'Налог не найден' };
+  }
+
+  taxationState.currentRates = {
+    ...taxationState.currentRates,
+    [taxType]: Number(newRate)
+  };
+
+  const base = taxationState.taxBase?.[taxType] || 0;
+  const efficiency = taxationState.collectionEfficiency?.[taxType] || 0;
+  const newRevenue = taxationHelpers.calculateTaxRevenue(taxType, Number(newRate), base, efficiency);
+  const incomeKey = TAX_INCOME_MAP[taxType];
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+
+  if (incomeKey) {
+    financeState.cityBudget = {
+      ...financeState.cityBudget,
+      monthlyIncome: {
+        ...financeState.cityBudget.monthlyIncome,
+        [incomeKey]: Math.round(newRevenue / 12)
+      }
+    };
+  }
+
+  taxationState.taxMetrics = {
+    ...taxationState.taxMetrics,
+    totalRevenue: Object.keys(taxationState.currentRates).reduce((total, typeKey) => {
+      const rate = taxationState.currentRates[typeKey];
+      const baseValue = taxationState.taxBase?.[typeKey] || 0;
+      const eff = taxationState.collectionEfficiency?.[typeKey] || 0;
+      return total + taxationHelpers.calculateTaxRevenue(typeKey, rate, baseValue, eff);
+    }, 0)
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    financeState,
+    taxationState
+  };
+
+  if (Number(newRate) > currentRate) {
+    updatedState.mayorRating = clamp((state.mayorRating || 0) - 2, GameConstants.MIN_MAYOR_RATING, GameConstants.MAX_MAYOR_RATING);
+  } else if (Number(newRate) < currentRate) {
+    updatedState.mayorRating = clamp((state.mayorRating || 0) + 2, GameConstants.MIN_MAYOR_RATING, GameConstants.MAX_MAYOR_RATING);
+  }
+
+  return updatedState;
+};
+
+const handleApplyBudgetChanges = (state, payload = {}) => {
+  const { changes = {} } = payload;
+  const taxationState = state.taxationState ? deepClone(state.taxationState) : deepClone(initialTaxationState);
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+
+  Object.entries(changes).forEach(([category, amount]) => {
+    if (taxationState.expenditureStructure?.[category]) {
+      taxationState.expenditureStructure[category] = {
+        ...taxationState.expenditureStructure[category],
+        amount: Number(amount)
+      };
+
+      const mappedCategory = EXPENDITURE_TO_BUDGET[category];
+      if (mappedCategory && financeState.cityBudget?.allocated) {
+        financeState.cityBudget.allocated = {
+          ...financeState.cityBudget.allocated,
+          [mappedCategory]: Number(amount)
+        };
+      }
+    }
+  });
+
+  const total = Object.values(taxationState.expenditureStructure).reduce((sum, entry) => sum + (entry.amount || 0), 0);
+  taxationState.expenditureStructure = Object.entries(taxationState.expenditureStructure).reduce((acc, [key, entry]) => {
+    acc[key] = {
+      ...entry,
+      percentage: total > 0 ? (entry.amount / total) * 100 : 0
+    };
+    return acc;
+  }, {});
+
+  return {
+    ...state,
+    errorMessage: null,
+    taxationState,
+    financeState
+  };
+};
+
+const handleStartConstructionProject = (state, payload = {}) => {
+  const { projectId, kickbacks = [] } = payload;
+  const project = constructionProjects.find((item) => item.id === projectId);
+
+  if (!project) {
+    return { ...state, errorMessage: 'Строительный проект не найден' };
+  }
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+
+  const projectCostInfo = constructionHelpers.calculateProjectCost(project, kickbacks.map((item) => item.type || item));
+  const totalCost = projectCostInfo.total_cost;
+  const kickbackAmount = projectCostInfo.kickback_amount;
+
+  if (!cityAccount || (cityAccount.balance || 0) < totalCost) {
+    return { ...state, errorMessage: 'Недостаточно средств для строительства' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -totalCost);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.CITY_CHECKING,
+    -totalCost,
+    budget
+  ));
+
+  if (kickbackAmount > 0) {
+    updatedBankingState = adjustBankAccountBalance(updatedBankingState, BankAccountTypes.OFFSHORE, kickbackAmount);
+    ({ financeState, budget, personalFinances } = applyBankAccountChange(
+      financeState,
+      BankAccountTypes.OFFSHORE,
+      kickbackAmount,
+      budget
+    ));
+  }
+
+  const constructionState = state.constructionState ? deepClone(state.constructionState) : deepClone(initialConstructionState);
+  const newProject = {
+    id: project.id,
+    startDate: Date.now(),
+    monthsPassed: 0,
+    status: ConstructionPhases.PLANNING,
+    kickbacksSelected: kickbacks.map((item) => item.type || item),
+    kickbacksReceived: kickbackAmount,
+    totalCost: project.cost
+  };
+
+  constructionState.activeProjects = [newProject, ...(constructionState.activeProjects || [])];
+  constructionState.constructionMetrics = {
+    ...constructionState.constructionMetrics,
+    totalProjects: (constructionState.constructionMetrics?.totalProjects || 0) + 1,
+    totalInvestment: (constructionState.constructionMetrics?.totalInvestment || 0) + project.cost
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    constructionState
+  };
+
+  if (project.benefits?.tax_revenue_annual) {
+    financeState.cityBudget = {
+      ...financeState.cityBudget,
+      monthlyIncome: {
+        ...financeState.cityBudget.monthlyIncome,
+        [IncomeTypes.LOCAL_TAXES]: (financeState.cityBudget.monthlyIncome?.[IncomeTypes.LOCAL_TAXES] || 0) + Math.round(project.benefits.tax_revenue_annual / 12)
+      }
+    };
+  }
+
+  if (project.benefits?.jobs_permanent) {
+    updatedState.unemployment = Math.max(0, (state.unemployment || 0) - project.benefits.jobs_permanent * 0.01);
+  }
+
+  return updatedState;
+};
+
+const handleUpgradeUtility = (state, payload = {}) => {
+  const { utilityId } = payload;
+  const service = utilityServices.find((item) => item.id === utilityId);
+
+  if (!service) {
+    return { ...state, errorMessage: 'Коммунальная услуга не найдена' };
+  }
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const cityAccount = bankingState.accounts?.[BankAccountTypes.CITY_CHECKING];
+  if (!cityAccount || (cityAccount.balance || 0) < service.cost) {
+    return { ...state, errorMessage: 'Недостаточно средств для модернизации услуги' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -service.cost);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.CITY_CHECKING,
+    -service.cost,
+    budget
+  ));
+
+  const constructionState = state.constructionState ? deepClone(state.constructionState) : deepClone(initialConstructionState);
+  const utilityState = constructionState.utilities?.[service.type] || { coverage: 0, quality: 0, satisfaction: 0 };
+  constructionState.utilities = {
+    ...constructionState.utilities,
+    [service.type]: {
+      ...utilityState,
+      coverage: clamp(utilityState.coverage + (service.benefits?.coverage_increase || 0)),
+      quality: clamp(utilityState.quality + (service.benefits?.quality_increase || 0)),
+      satisfaction: clamp(utilityState.satisfaction + (service.benefits?.citizen_satisfaction ? Object.values(service.benefits.citizen_satisfaction).reduce((sum, value) => sum + value, 0) / 2 : 5))
+    }
+  };
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    constructionState
+  };
+
+  if (service.benefits?.citizen_satisfaction && state.citizensState) {
+    const citizensState = state.citizensState ? deepClone(state.citizensState) : deepClone(initialCitizensState);
+    Object.entries(service.benefits.citizen_satisfaction).forEach(([groupKey, change]) => {
+      const key = Object.keys(citizensState.groups).find((id) => id.includes(groupKey));
+      if (key && citizensState.groups[key]) {
+        citizensState.groups[key] = {
+          ...citizensState.groups[key],
+          satisfaction: clamp((citizensState.groups[key].satisfaction || 0) + change)
+        };
+      }
+    });
+    updatedState.citizensState = citizensState;
+  }
+
+  updatedState.infrastructure = clamp((state.infrastructure || 0) + (service.benefits?.quality_increase || 5));
+
+  return updatedState;
+};
+
+const handleMakePersonalPurchase = (state, payload = {}) => {
+  const { optionId, customAmount = null } = payload;
+  const option = personalSpendingOptions.find((item) => item.id === optionId);
+  const amount = Number(customAmount || option?.cost || 0);
+
+  if (!option) {
+    return { ...state, errorMessage: 'Опция траты не найдена' };
+  }
+
+  if (!amount || amount <= 0) {
+    return { ...state, errorMessage: 'Некорректная сумма покупки' };
+  }
+
+  const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+  const personalAccount = bankingState.accounts?.[BankAccountTypes.PERSONAL_CHECKING];
+  if (!personalAccount || (personalAccount.balance || 0) < amount) {
+    return { ...state, errorMessage: 'Недостаточно личных средств' };
+  }
+
+  let updatedBankingState = adjustBankAccountBalance(bankingState, BankAccountTypes.PERSONAL_CHECKING, -amount);
+
+  let financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+  let budget = state.budget || 0;
+  let personalFinances;
+
+  ({ financeState, budget, personalFinances } = applyBankAccountChange(
+    financeState,
+    BankAccountTypes.PERSONAL_CHECKING,
+    -amount,
+    budget
+  ));
+
+  const personalSpendingState = state.personalSpendingState ? deepClone(state.personalSpendingState) : deepClone(initialPersonalSpendingState);
+  personalSpendingState.spendingHistory = [
+    {
+      id: Date.now(),
+      optionId,
+      amount,
+      type: option.type,
+      timestamp: Date.now()
+    },
+    ...(personalSpendingState.spendingHistory || [])
+  ].slice(0, 50);
+
+  if (option.type === SpendingTypes.RECURRING) {
+    personalSpendingState.recurringExpenses = [
+      { optionId, amount },
+      ...(personalSpendingState.recurringExpenses || [])
+    ];
+  }
+
+  if (option.type === SpendingTypes.INVESTMENT) {
+    personalSpendingState.assets = [
+      {
+        optionId,
+        purchase_price: amount,
+        purchase_date: Date.now(),
+        annual_appreciation: option.benefits?.annual_appreciation || 0
+      },
+      ...(personalSpendingState.assets || [])
+    ];
+  }
+
+  personalSpendingState.totalSpent = (personalSpendingState.totalSpent || 0) + amount;
+  personalSpendingState.totalAssets = personalSpendingHelpers.calculateAssetValue(personalSpendingState.assets, state);
+  personalSpendingState.monthlyExpenses = personalSpendingHelpers.calculateMonthlyExpenses(personalSpendingState.recurringExpenses);
+  personalSpendingState.detectionRisk = personalSpendingHelpers.calculateDetectionRisk(personalSpendingState.spendingHistory, state);
+  personalSpendingState.lifestyleQuality = personalSpendingHelpers.calculateLifestyleQuality(personalSpendingState.assets, personalSpendingState.recurringExpenses);
+  personalSpendingState.familyHappiness = personalSpendingHelpers.calculateFamilyHappiness(personalSpendingState.spendingHistory, personalSpendingState.assets);
+
+  const updatedState = {
+    ...state,
+    errorMessage: null,
+    bankingState: updatedBankingState,
+    financeState,
+    budget,
+    personalFinances,
+    personalSpendingState
+  };
+
+  if (option.benefits?.family_happiness) {
+    updatedState.familyHappiness = clamp((state.familyHappiness || 0) + option.benefits.family_happiness);
+  }
+
+  if (option.benefits?.status_boost) {
+    updatedState.mayorRating = clamp(
+      (state.mayorRating || 0) + option.benefits.status_boost * 0.2,
+      GameConstants.MIN_MAYOR_RATING,
+      GameConstants.MAX_MAYOR_RATING
+    );
+  }
+
+  if (option.consequences?.media_attention) {
+    updatedState.media_attention = (state.media_attention || 0) + option.consequences.media_attention;
+  }
+
+  if (option.consequences?.corruption_suspicion && financeState.risks) {
+    financeState.risks = {
+      ...financeState.risks,
+      mediaAttention: clamp((financeState.risks.mediaAttention || 0) + option.consequences.corruption_suspicion)
+    };
+  }
+
+  return updatedState;
 };
 
 // Reducer для управления состоянием игры
 const gameReducer = (state, action) => {
   switch (action.type) {
     case GAME_ACTIONS.LOAD_GAME:
-      const loadedState = action.payload || initialGameState;
-      return {
-        ...loadedState,
-        financeState: loadedState.financeState || initialFinanceState
-      };
+      return mergeGameState(action.payload);
 
     case GAME_ACTIONS.UPDATE_GAME_STATE:
-      return gameLogic.updateGameState(state);
+      return mergeGameState(gameLogic.updateGameState(state));
 
     case GAME_ACTIONS.PROCESS_EVENT_DECISION:
       return gameLogic.processEventDecision(state, action.eventId, action.optionId);
@@ -68,7 +2207,7 @@ const gameReducer = (state, action) => {
 
     case GAME_ACTIONS.RESET_GAME:
       gameLogic.resetGame();
-      return initialGameState;
+      return mergeGameState();
 
     case GAME_ACTIONS.CLEAR_ERROR:
       return {
@@ -76,10 +2215,17 @@ const gameReducer = (state, action) => {
         errorMessage: null
       };
 
-    case GAME_ACTIONS.REALLOCATE_BUDGET:
-      const { fromCategory, toCategory, amount } = action.payload;
+    case GAME_ACTIONS.REALLOCATE_BUDGET: {
+      const { fromCategory, toCategory, amount } = action.payload || {};
       const currentFinanceState = state.financeState || initialFinanceState;
-      
+
+      if (!fromCategory || !toCategory || !amount || amount <= 0) {
+        return {
+          ...state,
+          errorMessage: 'Некорректные параметры перераспределения бюджета'
+        };
+      }
+
       const fromAllocated = currentFinanceState.cityBudget.allocated[fromCategory] || 0;
       const fromSpent = currentFinanceState.cityBudget.spent[fromCategory] || 0;
       const availableFromCategory = fromAllocated - fromSpent;
@@ -105,15 +2251,22 @@ const gameReducer = (state, action) => {
           }
         }
       };
+    }
 
-    case GAME_ACTIONS.PERFORM_CORRUPTION:
-      const { type, amount: corruptionAmount, category } = action.payload;
+    case GAME_ACTIONS.PERFORM_CORRUPTION: {
+      const { type, amount: corruptionAmount, category } = action.payload || {};
       const financeState = state.financeState || initialFinanceState;
-      
-      // Проверяем возможность операции
+
+      if (!type || !category || !corruptionAmount || corruptionAmount <= 0) {
+        return {
+          ...state,
+          errorMessage: 'Некорректные параметры коррупционной операции'
+        };
+      }
+
       const canPerform = financeHelpers.canPerformCorruption(
-        corruptionAmount, 
-        type, 
+        corruptionAmount,
+        type,
         financeState
       );
 
@@ -124,7 +2277,6 @@ const gameReducer = (state, action) => {
         };
       }
 
-      // Проверяем наличие средств в категории
       const categoryAllocated = financeState.cityBudget.allocated[category] || 0;
       const categorySpentCurrent = financeState.cityBudget.spent[category] || 0;
       const availableInCategory = categoryAllocated - categorySpentCurrent;
@@ -136,7 +2288,6 @@ const gameReducer = (state, action) => {
         };
       }
 
-      // Рассчитываем риски
       const riskIncrease = Math.min(20, corruptionAmount / 100000);
       const newRisks = {
         ...financeState.risks,
@@ -145,7 +2296,6 @@ const gameReducer = (state, action) => {
         federalAttention: Math.min(100, (financeState.risks.federalAttention || 0) + riskIncrease * 0.3)
       };
 
-      // Определяем куда поступают средства
       let targetAccount = 'checking';
       if (type === 'kickbacks') targetAccount = 'cash';
       if (type === 'embezzlement') targetAccount = 'offshore';
@@ -165,8 +2315,8 @@ const gameReducer = (state, action) => {
             ...financeState.personalFinances,
             accounts: {
               ...financeState.personalFinances.accounts,
-              [targetAccount]: (financeState.personalFinances.accounts[targetAccount] || 0) + 
-                              corruptionAmount * 0.8 // 20% "расходы" на операцию
+              [targetAccount]: (financeState.personalFinances.accounts[targetAccount] || 0) +
+                              corruptionAmount * 0.8
             }
           },
           corruptionHistory: [
@@ -184,6 +2334,7 @@ const gameReducer = (state, action) => {
         },
         mayorRating: Math.max(0, state.mayorRating - riskIncrease * 0.1)
       };
+    }
 
     case GAME_ACTIONS.UPDATE_FINANCE_STATE:
       return {
@@ -193,6 +2344,78 @@ const gameReducer = (state, action) => {
           ...action.payload
         }
       };
+
+    case GAME_ACTIONS.BUY_STOCK:
+      return handleBuyStock(state, action.payload);
+
+    case GAME_ACTIONS.SELL_STOCK:
+      return handleSellStock(state, action.payload);
+
+    case GAME_ACTIONS.TRANSFER_FUNDS:
+      return handleTransferFunds(state, action.payload);
+
+    case GAME_ACTIONS.TAKE_LOAN:
+      return handleTakeLoan(state, action.payload);
+
+    case GAME_ACTIONS.CREATE_DEPOSIT:
+      return handleCreateDeposit(state, action.payload);
+
+    case GAME_ACTIONS.PROMOTE_EMPLOYEE:
+      return handlePromoteEmployee(state, action.payload);
+
+    case GAME_ACTIONS.FIRE_EMPLOYEE:
+      return handleFireEmployee(state, action.payload);
+
+    case GAME_ACTIONS.CHANGE_EMPLOYEE_SALARY:
+      return handleChangeEmployeeSalary(state, action.payload);
+
+    case GAME_ACTIONS.IMPLEMENT_POLICY:
+      return handleImplementPolicy(state, action.payload);
+
+    case GAME_ACTIONS.MAKE_GOVERNMENT_DECISION:
+      return handleMakeGovernmentDecision(state, action.payload);
+
+    case GAME_ACTIONS.MAKE_INVESTMENT:
+      return handleMakeInvestment(state, action.payload);
+
+    case GAME_ACTIONS.WITHDRAW_INVESTMENT:
+      return handleWithdrawInvestment(state, action.payload);
+
+    case GAME_ACTIONS.IMPLEMENT_INDUSTRIAL_PROJECT:
+      return handleImplementIndustrialProject(state, action.payload);
+
+    case GAME_ACTIONS.MODERNIZE_ENTERPRISE:
+      return handleModernizeEnterprise(state, action.payload);
+
+    case GAME_ACTIONS.EXECUTE_SECURITY_OPERATION:
+      return handleExecuteSecurityOperation(state, action.payload);
+
+    case GAME_ACTIONS.MITIGATE_THREAT:
+      return handleMitigateThreat(state, action.payload);
+
+    case GAME_ACTIONS.RESPOND_TO_ISSUE:
+      return handleRespondToIssue(state, action.payload);
+
+    case GAME_ACTIONS.SCHEDULE_MEETING:
+      return handleScheduleMeeting(state, action.payload);
+
+    case GAME_ACTIONS.IMPLEMENT_TAX_POLICY:
+      return handleImplementTaxPolicy(state, action.payload);
+
+    case GAME_ACTIONS.CHANGE_TAX_RATE:
+      return handleChangeTaxRate(state, action.payload);
+
+    case GAME_ACTIONS.APPLY_BUDGET_CHANGES:
+      return handleApplyBudgetChanges(state, action.payload);
+
+    case GAME_ACTIONS.START_CONSTRUCTION_PROJECT:
+      return handleStartConstructionProject(state, action.payload);
+
+    case GAME_ACTIONS.UPGRADE_UTILITY:
+      return handleUpgradeUtility(state, action.payload);
+
+    case GAME_ACTIONS.MAKE_PERSONAL_PURCHASE:
+      return handleMakePersonalPurchase(state, action.payload);
 
     default:
       return state;
@@ -297,24 +2520,216 @@ export const GameProvider = ({ children }) => {
     },
 
     // Финансовые операции
-    reallocateBudget: (fromCategory, toCategory, amount) => {
-      dispatch({ 
-        type: GAME_ACTIONS.REALLOCATE_BUDGET, 
-        payload: { fromCategory, toCategory, amount }
+    reallocateBudget: (fromOrChanges, maybeTo, maybeAmount) => {
+      if (typeof fromOrChanges === 'object' && fromOrChanges !== null && !Array.isArray(fromOrChanges)) {
+        dispatch({
+          type: GAME_ACTIONS.APPLY_BUDGET_CHANGES,
+          payload: { changes: fromOrChanges }
+        });
+        return;
+      }
+
+      dispatch({
+        type: GAME_ACTIONS.REALLOCATE_BUDGET,
+        payload: {
+          fromCategory: fromOrChanges,
+          toCategory: maybeTo,
+          amount: maybeAmount
+        }
       });
     },
 
     performCorruption: (type, amount, category) => {
-      dispatch({ 
-        type: GAME_ACTIONS.PERFORM_CORRUPTION, 
+      const financeState = gameState.financeState || initialFinanceState;
+      const canPerform = financeHelpers.canPerformCorruption(amount, type, financeState);
+
+      let success = canPerform.canPerform;
+      let error;
+
+      if (success) {
+        const allocated = financeState.cityBudget?.allocated?.[category] || 0;
+        const spent = financeState.cityBudget?.spent?.[category] || 0;
+        if (allocated - spent < amount) {
+          success = false;
+          error = 'Недостаточно средств в выбранной категории';
+        }
+      } else {
+        error = canPerform.reason;
+      }
+
+      dispatch({
+        type: GAME_ACTIONS.PERFORM_CORRUPTION,
         payload: { type, amount, category }
       });
+
+      return { success, error };
     },
 
     updateFinanceState: (financeUpdate) => {
-      dispatch({ 
-        type: GAME_ACTIONS.UPDATE_FINANCE_STATE, 
+      dispatch({
+        type: GAME_ACTIONS.UPDATE_FINANCE_STATE,
         payload: financeUpdate
+      });
+    },
+
+    buyStock: (stockId, quantity, price, accountType, commission = 0) => {
+      dispatch({
+        type: GAME_ACTIONS.BUY_STOCK,
+        payload: { stockId, quantity: Number(quantity), price, accountType, commission }
+      });
+    },
+
+    sellStock: (stockId, quantity, price, accountType, commission = 0) => {
+      dispatch({
+        type: GAME_ACTIONS.SELL_STOCK,
+        payload: { stockId, quantity: Number(quantity), price, accountType, commission }
+      });
+    },
+
+    transferFunds: (fromAccount, toAccount, amount) => {
+      dispatch({
+        type: GAME_ACTIONS.TRANSFER_FUNDS,
+        payload: { fromAccount, toAccount, amount: Number(amount) }
+      });
+    },
+
+    takeLoan: (loanId) => {
+      dispatch({
+        type: GAME_ACTIONS.TAKE_LOAN,
+        payload: { loanId }
+      });
+    },
+
+    createDeposit: (depositId, amount) => {
+      dispatch({
+        type: GAME_ACTIONS.CREATE_DEPOSIT,
+        payload: { depositId, amount: Number(amount) }
+      });
+    },
+
+    promoteEmployee: (employeeId) => {
+      dispatch({
+        type: GAME_ACTIONS.PROMOTE_EMPLOYEE,
+        payload: { employeeId }
+      });
+    },
+
+    fireEmployee: (employeeId) => {
+      dispatch({
+        type: GAME_ACTIONS.FIRE_EMPLOYEE,
+        payload: { employeeId }
+      });
+    },
+
+    changeEmployeeSalary: (employeeId, salary) => {
+      dispatch({
+        type: GAME_ACTIONS.CHANGE_EMPLOYEE_SALARY,
+        payload: { employeeId, salary }
+      });
+    },
+
+    implementPolicy: (policyId) => {
+      dispatch({
+        type: GAME_ACTIONS.IMPLEMENT_POLICY,
+        payload: { policyId }
+      });
+    },
+
+    makeGovernmentDecision: (decisionType, data) => {
+      dispatch({
+        type: GAME_ACTIONS.MAKE_GOVERNMENT_DECISION,
+        payload: { decisionType, data }
+      });
+    },
+
+    makeInvestment: (investmentId, amount) => {
+      dispatch({
+        type: GAME_ACTIONS.MAKE_INVESTMENT,
+        payload: { investmentId, amount: Number(amount) }
+      });
+    },
+
+    withdrawInvestment: (investmentId, amount) => {
+      dispatch({
+        type: GAME_ACTIONS.WITHDRAW_INVESTMENT,
+        payload: { investmentId, amount: Number(amount) }
+      });
+    },
+
+    implementIndustrialProject: (projectId, kickbacks) => {
+      dispatch({
+        type: GAME_ACTIONS.IMPLEMENT_INDUSTRIAL_PROJECT,
+        payload: { projectId, kickbacks }
+      });
+    },
+
+    modernizeEnterprise: (enterpriseId) => {
+      dispatch({
+        type: GAME_ACTIONS.MODERNIZE_ENTERPRISE,
+        payload: { enterpriseId }
+      });
+    },
+
+    executeSecurityOperation: (agencyId, operation) => {
+      dispatch({
+        type: GAME_ACTIONS.EXECUTE_SECURITY_OPERATION,
+        payload: { agencyId, operation }
+      });
+    },
+
+    mitigateThreat: (threatId, mitigationOption) => {
+      dispatch({
+        type: GAME_ACTIONS.MITIGATE_THREAT,
+        payload: { threatId, mitigationOption }
+      });
+    },
+
+    respondToIssue: (issueId, response) => {
+      dispatch({
+        type: GAME_ACTIONS.RESPOND_TO_ISSUE,
+        payload: { issueId, response }
+      });
+    },
+
+    scheduleMeeting: (groupId) => {
+      dispatch({
+        type: GAME_ACTIONS.SCHEDULE_MEETING,
+        payload: { groupId }
+      });
+    },
+
+    implementTaxPolicy: (policyId) => {
+      dispatch({
+        type: GAME_ACTIONS.IMPLEMENT_TAX_POLICY,
+        payload: { policyId }
+      });
+    },
+
+    changeTaxRate: (taxType, newRate) => {
+      dispatch({
+        type: GAME_ACTIONS.CHANGE_TAX_RATE,
+        payload: { taxType, newRate }
+      });
+    },
+
+    startConstructionProject: (projectId, kickbacks) => {
+      dispatch({
+        type: GAME_ACTIONS.START_CONSTRUCTION_PROJECT,
+        payload: { projectId, kickbacks }
+      });
+    },
+
+    upgradeUtility: (utilityId) => {
+      dispatch({
+        type: GAME_ACTIONS.UPGRADE_UTILITY,
+        payload: { utilityId }
+      });
+    },
+
+    makePersonalPurchase: (optionId, amount) => {
+      dispatch({
+        type: GAME_ACTIONS.MAKE_PERSONAL_PURCHASE,
+        payload: { optionId, amount: Number(amount) }
       });
     }
   };
@@ -328,8 +2743,7 @@ export const GameProvider = ({ children }) => {
     gameTips: gameLogic.getGameTips(gameState),
     
     // Доступные проекты
-    availableProjects: gameState.activeProjects?.length < 10 ? 
-      [] : [], // Будет реализовано в компонентах
+    availableProjects: projectHelpers.getAvailableProjects(gameState),
     
     // Форматированная дата
     currentDate: `${gameState.currentDay}.${gameState.currentMonth.toString().padStart(2, '0')}.${gameState.currentYear}`,
@@ -386,33 +2800,6 @@ export const GameProvider = ({ children }) => {
       {children}
     </GameContext.Provider>
   );
-};
-
-// Хук для использования контекста
-export const useGame = () => {
-  const context = useContext(GameContext);
-  if (!context) {
-    throw new Error('useGame должен использоваться внутри GameProvider');
-  }
-  return context;
-};
-
-// Хук для получения только состояния (оптимизация)
-export const useGameState = () => {
-  const { gameState } = useGame();
-  return gameState;
-};
-
-// Хук для получения только действий
-export const useGameActions = () => {
-  const { actions } = useGame();
-  return actions;
-};
-
-// Хок для получения вычисляемых значений
-export const useGameComputed = () => {
-  const { computed } = useGame();
-  return computed;
 };
 
 export default GameContext;

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -295,11 +295,10 @@ export const gameEvents = [
         text: 'Организовать грандиозный фестиваль',
         cost: 8000000,
         effects: {
-          budget: -8000000,
+          budget: -6000000,
           happiness: 20,
           mayorRating: 12,
-          // Привлечение туристов
-          budget: 2000000 // доход от туризма
+          tourismIncome: 2000000 // доход от туризма
         }
       },
       {

--- a/src/hooks/useGame.js
+++ b/src/hooks/useGame.js
@@ -1,0 +1,28 @@
+import { useContext } from 'react';
+
+import GameContext from '@/contexts/GameContext.jsx';
+
+export const useGame = () => {
+  const context = useContext(GameContext);
+
+  if (!context) {
+    throw new Error('useGame должен использоваться внутри GameProvider');
+  }
+
+  return context;
+};
+
+export const useGameState = () => {
+  const { gameState } = useGame();
+  return gameState;
+};
+
+export const useGameActions = () => {
+  const { actions } = useGame();
+  return actions;
+};
+
+export const useGameComputed = () => {
+  const { computed } = useGame();
+  return computed;
+};

--- a/src/types/citizens.js
+++ b/src/types/citizens.js
@@ -503,19 +503,19 @@ export const citizenHelpers = {
   },
 
   // Расчет влияния группы на рейтинг мэра
-  calculateGroupInfluence: (group, gameState) => {
+  calculateGroupInfluence: (group) => {
     let influence = group.influence;
-    
+
     // Корректировка на основе политической активности
     influence *= (group.characteristics.political_activity / 100);
-    
+
     // Корректировка на основе явки на выборы
     influence *= (group.demographics.voting_turnout / 100);
-    
+
     // Корректировка на основе размера группы
     const populationWeight = Math.log(group.population / 1000) / 10;
     influence *= (1 + populationWeight);
-    
+
     return Math.min(100, influence);
   },
 
@@ -575,11 +575,11 @@ export const citizenHelpers = {
   },
 
   // Расчет изменения удовлетворенности
-  calculateSatisfactionChange: (response, issue, group, gameState) => {
+  calculateSatisfactionChange: (response, issue, group) => {
     const effectiveness = citizenHelpers.calculateResponseEffectiveness(response, issue, group);
-    
+
     let change = 0;
-    
+
     if (response.type === ResponseTypes.FUNDING && response.amount >= issue.cost) {
       change = 15 + (effectiveness - 50) * 0.3;
     } else if (response.type === ResponseTypes.PROMISE) {
@@ -589,15 +589,15 @@ export const citizenHelpers = {
     } else if (response.type === ResponseTypes.IGNORE) {
       change = -10 - (100 - effectiveness) * 0.2;
     }
-    
+
     // Корректировка на основе истории взаимодействий
-    const promisesFulfillmentRate = group.totalPromises > 0 ? 
+    const promisesFulfillmentRate = group.totalPromises > 0 ?
       group.fulfilledPromises / group.totalPromises : 1;
-    
+
     if (response.type === ResponseTypes.PROMISE) {
       change *= promisesFulfillmentRate;
     }
-    
+
     return Math.round(change);
   },
 
@@ -652,14 +652,14 @@ export const citizenHelpers = {
   },
 
   // Генерация события на основе недовольства
-  generateProtestEvent: (groups, gameState) => {
+  generateProtestEvent: (groups) => {
     const protestPotential = citizenHelpers.calculateProtestPotential(groups);
-    
+
     if (protestPotential > 30 && Math.random() < 0.3) {
       const dissatisfiedGroups = Object.values(groups)
         .filter(group => group.satisfaction < 40)
         .sort((a, b) => a.satisfaction - b.satisfaction);
-      
+
       if (dissatisfiedGroups.length > 0) {
         const mainGroup = dissatisfiedGroups[0];
         return {
@@ -675,7 +675,7 @@ export const citizenHelpers = {
         };
       }
     }
-    
+
     return null;
   }
 };

--- a/src/types/construction.js
+++ b/src/types/construction.js
@@ -662,16 +662,17 @@ export const constructionHelpers = {
 
   // Расчет влияния на удовлетворенность граждан
   calculateSatisfactionImpact: (project, gameState) => {
-    let impact = { ...project.benefits.citizen_satisfaction } || {};
-    
+    const satisfactionBenefits = project.benefits?.citizen_satisfaction || {};
+    const impact = { ...satisfactionBenefits };
+
     // Модификаторы влияния
     const completionBonus = 1.2; // бонус за завершение
     const qualityModifier = gameState.construction_quality || 1;
-    
+
     Object.keys(impact).forEach(group => {
       impact[group] = Math.round(impact[group] * completionBonus * qualityModifier);
     });
-    
+
     return impact;
   },
 

--- a/src/types/game.js
+++ b/src/types/game.js
@@ -1,36 +1,104 @@
+import { initialFinanceState, PersonalAccountTypes } from './finance.js';
+import { initialBankingState } from './banking.js';
+import { initialGovernmentState } from './government.js';
+import { initialInvestmentState } from './investments.js';
+import { initialIndustryState } from './industry.js';
+import { initialSecurityState } from './security.js';
+import { initialCitizensState } from './citizens.js';
+import { initialTaxationState } from './taxation.js';
+import { initialConstructionState } from './construction.js';
+import { initialPersonalSpendingState } from './personalSpending.js';
+
 // Типы данных для игрового состояния
 
-// Основное состояние игры
-export const initialGameState = {
-  // Основные показатели
-  budget: 50000000, // Бюджет в рублях
-  mayorRating: 50, // Рейтинг мэра (0-100)
-  population: 372123, // Население
-  happiness: 50, // Уровень счастья населения (0-100)
-  ecology: 40, // Экологический индекс (0-100)
-  infrastructure: 45, // Индекс инфраструктуры (0-100)
-  unemployment: 8.5, // Уровень безработицы (%)
-  
-  // Игровое время
-  currentDay: 1,
-  currentMonth: 1,
-  currentYear: 2025,
-  
-  // Активные проекты
-  activeProjects: [],
-  
-  // История событий
-  eventHistory: [],
-  
-  // Настройки игры
-  gameSpeed: 1, // Скорость игры (1 = нормальная)
-  isPaused: false,
-  
-  // Статистика
-  totalDecisions: 0,
-  successfulProjects: 0,
-  failedProjects: 0
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const buildPersonalFinancesSnapshot = (personalFinances) => ({
+  personal_account: personalFinances.accounts?.[PersonalAccountTypes.CHECKING] || 0,
+  savings_account: personalFinances.accounts?.[PersonalAccountTypes.SAVINGS] || 0,
+  offshore_account: personalFinances.accounts?.[PersonalAccountTypes.OFFSHORE] || 0,
+  crypto_account: personalFinances.accounts?.[PersonalAccountTypes.CRYPTO] || 0,
+  cash: personalFinances.accounts?.[PersonalAccountTypes.CASH] || 0,
+  monthlyIncome: clone(personalFinances.monthlyIncome || {}),
+  monthlyExpenses: clone(personalFinances.monthlyExpenses || {})
+});
+
+export const createInitialGameState = () => {
+  const financeState = clone(initialFinanceState);
+  const bankingState = clone(initialBankingState);
+  const governmentState = clone(initialGovernmentState);
+  const investmentState = clone(initialInvestmentState);
+  const industryState = clone(initialIndustryState);
+  const securityState = clone(initialSecurityState);
+  const citizensState = clone(initialCitizensState);
+  const taxationState = clone(initialTaxationState);
+  const constructionState = clone(initialConstructionState);
+  const personalSpendingState = clone(initialPersonalSpendingState);
+
+  const baseTimestamp = new Date('2025-01-01T08:00:00Z').getTime();
+
+  return {
+    // Основные показатели
+    budget: 50000000,
+    mayorRating: 50,
+    population: 372123,
+    happiness: 50,
+    ecology: 40,
+    infrastructure: 45,
+    unemployment: 8.5,
+
+    education: 52,
+    culture: 48,
+    corruption: 30,
+    corruption_level: 35,
+    media_attention: 25,
+    federal_relations: 60,
+    environmental_rating: 55,
+    construction_quality: 1,
+    familyHappiness: 50,
+
+    // Игровое время
+    currentDay: 1,
+    currentMonth: 1,
+    currentYear: 2025,
+    currentTimestamp: baseTimestamp,
+
+    // Активные проекты
+    activeProjects: [],
+
+    // История событий
+    eventHistory: [],
+
+    // Настройки игры
+    gameSpeed: 1,
+    isPaused: false,
+
+    // Статистика
+    totalDecisions: 0,
+    successfulProjects: 0,
+    failedProjects: 0,
+
+    // Комплексные подсистемы
+    financeState,
+    bankingState,
+    governmentState,
+    investmentState,
+    industryState,
+    securityState,
+    citizensState,
+    taxationState,
+    constructionState,
+    personalSpendingState,
+
+    // Связанные данные
+    personalFinances: buildPersonalFinancesSnapshot(financeState.personalFinances),
+    citizenGroups: clone(citizensState.groups),
+    budget_balance: 0
+  };
 };
+
+// Основное состояние игры
+export const initialGameState = createInitialGameState();
 
 // Типы событий
 export const EventTypes = {

--- a/src/types/government.js
+++ b/src/types/government.js
@@ -417,7 +417,7 @@ export const governmentHelpers = {
   },
 
   // Генерация случайного события в департаменте
-  generateDepartmentEvent: (department, employees) => {
+  generateDepartmentEvent: () => {
     const events = [
       {
         type: 'corruption_scandal',
@@ -494,7 +494,7 @@ export const governmentHelpers = {
   },
 
   // Поиск кандидатов на должность
-  findCandidates: (department, level, requirements = {}) => {
+  findCandidates: () => {
     // Здесь будет логика поиска кандидатов
     // Пока возвращаем заглушку
     return [];

--- a/src/types/investments.js
+++ b/src/types/investments.js
@@ -614,7 +614,7 @@ export const investmentHelpers = {
   },
 
   // Генерация случайных событий для инвестиций
-  generateInvestmentEvent: (investment) => {
+  generateInvestmentEvent: () => {
     const events = [
       {
         type: 'regulatory_change',

--- a/src/types/taxation.js
+++ b/src/types/taxation.js
@@ -626,7 +626,7 @@ export const taxationHelpers = {
   },
 
   // Генерация рекомендаций по налоговой политике
-  generateTaxRecommendations: (currentState, gameState) => {
+  generateTaxRecommendations: (currentState) => {
     const recommendations = [];
     
     // Анализ бюджетного баланса

--- a/src/utils/gameLogic.js
+++ b/src/utils/gameLogic.js
@@ -1,6 +1,87 @@
-import { gameStateHelpers, GameConstants } from '../types/game.js';
+import { gameStateHelpers, GameConstants, ProjectCategories, ProjectStatus } from '../types/game.js';
 import { eventHelpers } from '../data/events.js';
-import { projectHelpers } from '../data/projects.js';
+import { projectHelpers, cityProjects } from '../data/projects.js';
+import { initialFinanceState, financeHelpers, PersonalAccountTypes, IncomeTypes, BudgetCategories } from '../types/finance.js';
+import { initialBankingState, bankingHelpers, BankAccountTypes } from '../types/banking.js';
+import { initialGovernmentState, governmentHelpers } from '../types/government.js';
+import { initialInvestmentState, investmentHelpers, investmentOpportunities } from '../types/investments.js';
+import { initialIndustryState, industryHelpers, industrialProjects, ProjectStatus as IndustryProjectStatus } from '../types/industry.js';
+import { initialSecurityState, securityHelpers, ThreatLevels } from '../types/security.js';
+import { initialCitizensState, citizenHelpers } from '../types/citizens.js';
+import { initialTaxationState, taxationHelpers } from '../types/taxation.js';
+import { initialConstructionState, constructionHelpers, constructionProjects, ConstructionPhases } from '../types/construction.js';
+import { initialPersonalSpendingState, personalSpendingHelpers } from '../types/personalSpending.js';
+
+const deepClone = (value) => JSON.parse(JSON.stringify(value));
+
+const clamp = (value, min = 0, max = 100) => {
+  if (Number.isNaN(value)) return min;
+  return Math.max(min, Math.min(max, value));
+};
+
+const PERSONAL_BANK_ACCOUNT_MAP = {
+  [BankAccountTypes.PERSONAL_CHECKING]: PersonalAccountTypes.CHECKING,
+  [BankAccountTypes.PERSONAL_SAVINGS]: PersonalAccountTypes.SAVINGS,
+  [BankAccountTypes.PERSONAL_INVESTMENT]: PersonalAccountTypes.SAVINGS,
+  [BankAccountTypes.OFFSHORE]: PersonalAccountTypes.OFFSHORE
+};
+
+const isCityAccount = (accountType) => accountType?.startsWith('city');
+
+const adjustBankAccountBalance = (bankingState, accountType, delta) => {
+  if (!accountType || !bankingState?.accounts?.[accountType]) {
+    return 0;
+  }
+
+  const account = bankingState.accounts[accountType];
+  account.balance = Math.max(0, (account.balance || 0) + delta);
+  return account.balance;
+};
+
+const applyFinanceAccountChange = (financeState, accountType, delta) => {
+  let budgetDelta = 0;
+
+  if (!accountType || !financeState) {
+    return budgetDelta;
+  }
+
+  if (isCityAccount(accountType)) {
+    financeState.cityBudget.total = Math.max(0, (financeState.cityBudget.total || 0) + delta);
+    budgetDelta = delta;
+  } else {
+    const mappedAccount = PERSONAL_BANK_ACCOUNT_MAP[accountType] || PersonalAccountTypes.CHECKING;
+    const accounts = financeState.personalFinances.accounts || {};
+    accounts[mappedAccount] = Math.max(0, (accounts[mappedAccount] || 0) + delta);
+    financeState.personalFinances.accounts = accounts;
+  }
+
+  return budgetDelta;
+};
+
+const appendTransaction = (history, entry) => [entry, ...(history || [])].slice(0, 100);
+
+const buildPersonalFinancesSnapshot = (personalFinances) => ({
+  personal_account: personalFinances?.accounts?.[PersonalAccountTypes.CHECKING] || 0,
+  savings_account: personalFinances?.accounts?.[PersonalAccountTypes.SAVINGS] || 0,
+  offshore_account: personalFinances?.accounts?.[PersonalAccountTypes.OFFSHORE] || 0,
+  crypto_account: personalFinances?.accounts?.[PersonalAccountTypes.CRYPTO] || 0,
+  cash: personalFinances?.accounts?.[PersonalAccountTypes.CASH] || 0,
+  monthlyIncome: deepClone(personalFinances?.monthlyIncome || {}),
+  monthlyExpenses: deepClone(personalFinances?.monthlyExpenses || {})
+});
+
+const PROJECT_CATEGORY_TO_BUDGET = {
+  [ProjectCategories.INFRASTRUCTURE]: BudgetCategories.INFRASTRUCTURE,
+  [ProjectCategories.ECOLOGY]: BudgetCategories.ECOLOGY,
+  [ProjectCategories.SOCIAL]: BudgetCategories.SOCIAL,
+  [ProjectCategories.CULTURE]: BudgetCategories.CULTURE,
+  [ProjectCategories.SAFETY]: BudgetCategories.SECURITY,
+  [ProjectCategories.ECONOMY]: BudgetCategories.ADMINISTRATION
+};
+
+const getBudgetCategoryForProject = (category) => {
+  return PROJECT_CATEGORY_TO_BUDGET[category] || BudgetCategories.INFRASTRUCTURE;
+};
 
 // Основная игровая логика
 export const gameLogic = {
@@ -55,27 +136,591 @@ export const gameLogic = {
 
   // Ежемесячные обновления
   processMonthlyUpdates: (state) => {
-    let newState = { ...state };
+    const updatedState = { ...state };
 
-    // Расчет доходов и расходов
-    const monthlyIncome = gameStateHelpers.calculateMonthlyIncome(newState);
-    const monthlyExpenses = gameStateHelpers.calculateMonthlyExpenses(newState);
+    const financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+    const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+    const governmentState = state.governmentState ? deepClone(state.governmentState) : deepClone(initialGovernmentState);
+    const investmentState = state.investmentState ? deepClone(state.investmentState) : deepClone(initialInvestmentState);
+    const industryState = state.industryState ? deepClone(state.industryState) : deepClone(initialIndustryState);
+    const securityState = state.securityState ? deepClone(state.securityState) : deepClone(initialSecurityState);
+    const citizensState = state.citizensState ? deepClone(state.citizensState) : deepClone(initialCitizensState);
+    const taxationState = state.taxationState ? deepClone(state.taxationState) : deepClone(initialTaxationState);
+    const constructionState = state.constructionState ? deepClone(state.constructionState) : deepClone(initialConstructionState);
+    const personalSpendingState = state.personalSpendingState ? deepClone(state.personalSpendingState) : deepClone(initialPersonalSpendingState);
+
+    const activeProjects = (state.activeProjects || []).filter((project) => project.status === ProjectStatus.IN_PROGRESS);
+    const projectExpensesMap = {};
+
+    activeProjects.forEach((project) => {
+      const monthlyCost = project.financials?.monthlyCost ?? project.monthlyCost ?? 0;
+      if (!monthlyCost) return;
+
+      const category = project.budgetCategory || getBudgetCategoryForProject(project.category);
+      projectExpensesMap[project.id] = {
+        projectId: project.id,
+        title: project.title,
+        category,
+        monthlyCost
+      };
+    });
+
+    financeState.cityBudget.projectExpenses = projectExpensesMap;
+
+    let budget = state.budget ?? 0;
+
+    const monthMs = GameConstants.DAYS_PER_MONTH * 24 * 60 * 60 * 1000;
+    updatedState.currentTimestamp = (state.currentTimestamp || Date.now()) + monthMs;
+
+    // Финансовые потоки
+    const monthlyIncome = financeHelpers.getMonthlyIncome(financeState.cityBudget);
+    const monthlyExpenses = financeHelpers.getMonthlyExpenses(financeState.cityBudget);
     const netIncome = monthlyIncome - monthlyExpenses;
 
-    newState.budget += netIncome;
+    financeState.cityBudget.total = Math.max(0, (financeState.cityBudget.total || 0) + netIncome);
+    budget = Math.max(0, budget + netIncome);
+    updatedState.budget_balance = netIncome;
 
-    // Естественные изменения показателей
-    newState = gameLogic.applyNaturalDecay(newState);
+    const expenseBreakdown = financeHelpers.getMonthlyExpenseBreakdown(financeState.cityBudget);
+    const updatedSpent = { ...(financeState.cityBudget.spent || {}) };
 
-    // Случайные события
-    if (Math.random() < 0.3) { // 30% шанс события каждый месяц
-      const randomEvent = eventHelpers.getRandomEvent(newState);
+    Object.entries(expenseBreakdown).forEach(([category, expense]) => {
+      const allocated = financeState.cityBudget.allocated?.[category];
+      const previous = updatedSpent[category] || 0;
+      updatedSpent[category] = allocated !== undefined
+        ? Math.min(allocated, previous + expense)
+        : previous + expense;
+    });
+
+    financeState.cityBudget.spent = updatedSpent;
+
+    // Личные финансы мэра
+    const personalIncomeSum = Object.values(financeState.personalFinances.monthlyIncome || {}).reduce((sum, value) => sum + value, 0);
+    const recurringExpenses = personalSpendingHelpers.calculateMonthlyExpenses(personalSpendingState.recurringExpenses || []);
+    const personalExpensesSum = Object.values(financeState.personalFinances.monthlyExpenses || {}).reduce((sum, value) => sum + value, 0) + recurringExpenses;
+    const personalNet = personalIncomeSum - personalExpensesSum;
+
+    financeState.personalFinances.accounts[PersonalAccountTypes.CHECKING] = Math.max(
+      0,
+      (financeState.personalFinances.accounts[PersonalAccountTypes.CHECKING] || 0) + personalNet
+    );
+    financeState.personalFinances.monthlyExpenses = {
+      ...(financeState.personalFinances.monthlyExpenses || {}),
+      luxury: recurringExpenses
+    };
+
+    // Обработка кредитов
+    const updatedLoans = [];
+    (bankingState.loans || []).forEach((loan) => {
+      const loanEntry = { ...loan };
+      if (loanEntry.status && loanEntry.status !== 'active') {
+        updatedLoans.push(loanEntry);
+        return;
+      }
+
+      const paymentAmount = loanEntry.monthlyPayment || bankingHelpers.calculateLoanPayment(
+        loanEntry.remainingAmount || loanEntry.amount,
+        loanEntry.interestRate,
+        loanEntry.remainingMonths || loanEntry.term
+      );
+      const account = bankingState.accounts?.[loanEntry.accountType];
+
+      if (!account || (account.balance || 0) < paymentAmount) {
+        loanEntry.status = 'overdue';
+        loanEntry.missedPayments = (loanEntry.missedPayments || 0) + 1;
+        securityState.securityMetrics.investigationProbability = clamp(
+          (securityState.securityMetrics?.investigationProbability || 0) + 3,
+          0,
+          100
+        );
+        updatedLoans.push(loanEntry);
+        return;
+      }
+
+      account.balance = Math.max(0, (account.balance || 0) - paymentAmount);
+
+      const monthlyRate = loanEntry.interestRate / 100 / 12;
+      const interestPortion = (loanEntry.remainingAmount || loanEntry.amount) * monthlyRate;
+      const principalPayment = Math.max(0, paymentAmount - interestPortion);
+
+      loanEntry.remainingAmount = Math.max(0, (loanEntry.remainingAmount || loanEntry.amount) + interestPortion - paymentAmount);
+      loanEntry.remainingMonths = Math.max(0, (loanEntry.remainingMonths || loanEntry.term) - 1);
+      loanEntry.paymentHistory = [
+        {
+          id: Date.now(),
+          amount: paymentAmount,
+          interest: interestPortion,
+          principal: principalPayment,
+          timestamp: Date.now()
+        },
+        ...((loanEntry.paymentHistory || []).slice(0, 11))
+      ];
+
+      budget += applyFinanceAccountChange(financeState, loanEntry.accountType, -paymentAmount);
+
+      bankingState.transactionHistory = appendTransaction(bankingState.transactionHistory, {
+        id: Date.now(),
+        type: 'loan_payment',
+        loanId: loanEntry.offerId || loanEntry.id,
+        amount: paymentAmount,
+        accountType: loanEntry.accountType,
+        timestamp: Date.now()
+      });
+
+      if (loanEntry.remainingAmount <= 1 || loanEntry.remainingMonths === 0) {
+        loanEntry.remainingAmount = 0;
+        loanEntry.status = 'completed';
+        loanEntry.completedAt = Date.now();
+      }
+
+      updatedLoans.push(loanEntry);
+    });
+    bankingState.loans = updatedLoans;
+
+    // Обработка депозитов
+    const activeDeposits = [];
+    const maturedDeposits = [];
+    (bankingState.deposits || []).forEach((deposit) => {
+      const depositEntry = { ...deposit };
+      const monthlyRate = depositEntry.interestRate / 100 / 12;
+      const interest = depositEntry.amount * monthlyRate;
+
+      depositEntry.accruedInterest = (depositEntry.accruedInterest || 0) + interest;
+      depositEntry.remainingMonths = Math.max(0, (depositEntry.remainingMonths ?? depositEntry.term ?? 1) - 1);
+
+      if (isCityAccount(depositEntry.accountType)) {
+        financeState.cityBudget.monthlyIncome[IncomeTypes.INVESTMENTS] =
+          (financeState.cityBudget.monthlyIncome?.[IncomeTypes.INVESTMENTS] || 0) + Math.round(interest);
+      } else {
+        const currentInvestmentIncome = financeState.personalFinances.monthlyIncome?.investments || 0;
+        financeState.personalFinances.monthlyIncome = {
+          ...(financeState.personalFinances.monthlyIncome || {}),
+          investments: Math.round(currentInvestmentIncome + interest)
+        };
+      }
+
+      if (depositEntry.remainingMonths <= 0) {
+        const payout = depositEntry.amount + depositEntry.accruedInterest;
+        adjustBankAccountBalance(bankingState, depositEntry.accountType, payout);
+        budget += applyFinanceAccountChange(financeState, depositEntry.accountType, payout);
+
+        bankingState.transactionHistory = appendTransaction(bankingState.transactionHistory, {
+          id: Date.now(),
+          type: 'deposit_matured',
+          depositId: depositEntry.offerId || depositEntry.id,
+          amount: payout,
+          accountType: depositEntry.accountType,
+          timestamp: Date.now()
+        });
+
+        depositEntry.status = 'completed';
+        depositEntry.completedAt = Date.now();
+        maturedDeposits.push(depositEntry);
+      } else {
+        activeDeposits.push(depositEntry);
+      }
+    });
+    bankingState.deposits = activeDeposits;
+    if (maturedDeposits.length > 0) {
+      bankingState.completedDeposits = [
+        ...maturedDeposits,
+        ...(bankingState.completedDeposits || [])
+      ].slice(0, 20);
+    }
+
+    // Обновление состояния правительства
+    const departmentEfficiencies = [];
+    let totalMood = 0;
+    let employeeCount = 0;
+
+    Object.entries(governmentState.employees || {}).forEach(([department, employees]) => {
+      const updatedEmployees = employees.map((employee) => {
+        const updated = { ...employee };
+        updated.workload = clamp((employee.workload || 50) - 5);
+        updated.mood = clamp((employee.mood || 70) - 2);
+        totalMood += updated.mood;
+        employeeCount += 1;
+        return updated;
+      });
+
+      governmentState.employees[department] = updatedEmployees;
+      const efficiency = governmentHelpers.calculateDepartmentEfficiency(department, updatedEmployees);
+      departmentEfficiencies.push(efficiency);
+      if (governmentState.departmentSettings?.[department]) {
+        governmentState.departmentSettings[department] = {
+          ...governmentState.departmentSettings[department],
+          efficiency
+        };
+      }
+    });
+
+    if (employeeCount > 0) {
+      governmentState.performanceMetrics.employeeSatisfaction = Math.round(totalMood / employeeCount);
+    }
+    if (departmentEfficiencies.length > 0) {
+      governmentState.performanceMetrics.departmentEfficiency = Math.round(
+        departmentEfficiencies.reduce((sum, value) => sum + value, 0) / departmentEfficiencies.length
+      );
+    }
+    governmentState.performanceMetrics.decisionsPerMonth = 0;
+
+    // Инвестиции
+    const activeInvestments = [];
+    const completedInvestments = [];
+    (investmentState.activeInvestments || []).forEach((investment) => {
+      const opportunity = investmentOpportunities.find((item) => item.id === investment.id);
+      if (!opportunity) {
+        activeInvestments.push(investment);
+        return;
+      }
+
+      const investmentEntry = { ...investment };
+      investmentEntry.monthsPassed = (investmentEntry.monthsPassed || 0) + 1;
+
+      const progress = investmentHelpers.simulateInvestmentProgress(opportunity, investmentEntry.monthsPassed);
+      investmentEntry.progress = progress.progressPercent;
+      investmentEntry.remainingMonths = progress.remainingMonths;
+
+      if (progress.isCompleted) {
+        const payout = investmentHelpers.calculateCurrentValue(opportunity, investmentEntry.monthsPassed, investmentEntry.amount);
+        adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, payout);
+        budget += applyFinanceAccountChange(financeState, BankAccountTypes.CITY_CHECKING, payout);
+
+        const profit = payout - investmentEntry.amount;
+        investmentState.portfolio.totalReturns = (investmentState.portfolio?.totalReturns || 0) + Math.max(0, profit);
+
+        completedInvestments.push({
+          id: `${investmentEntry.id}_${Date.now()}`,
+          investmentId: investmentEntry.id,
+          amount: investmentEntry.amount,
+          returned: payout,
+          profit,
+          completedAt: Date.now()
+        });
+
+        if (opportunity.cityBenefits?.unemployment) {
+          updatedState.unemployment = Math.max(0, (updatedState.unemployment || 0) + opportunity.cityBenefits.unemployment);
+        }
+        if (opportunity.cityBenefits?.infrastructure) {
+          updatedState.infrastructure = clamp((updatedState.infrastructure || 0) + opportunity.cityBenefits.infrastructure);
+        }
+        if (opportunity.cityBenefits?.happiness) {
+          updatedState.happiness = clamp((updatedState.happiness || 0) + opportunity.cityBenefits.happiness);
+        }
+      } else {
+        activeInvestments.push(investmentEntry);
+      }
+    });
+    investmentState.activeInvestments = activeInvestments;
+    if (completedInvestments.length > 0) {
+      investmentState.completedInvestments = [
+        ...completedInvestments,
+        ...(investmentState.completedInvestments || [])
+      ].slice(0, 25);
+    }
+
+    let totalInvested = 0;
+    let activeValue = 0;
+    investmentState.activeInvestments.forEach((investment) => {
+      const opportunity = investmentOpportunities.find((item) => item.id === investment.id);
+      totalInvested += investment.amount;
+      if (opportunity) {
+        activeValue += investmentHelpers.calculateCurrentValue(opportunity, investment.monthsPassed || 0, investment.amount);
+      }
+    });
+    investmentState.portfolio.totalInvested = totalInvested;
+    investmentState.portfolio.activeValue = activeValue;
+
+    const totalProjectsCount = investmentState.activeInvestments.length + (investmentState.completedInvestments?.length || 0);
+    if (totalProjectsCount > 0) {
+      investmentState.investmentMetrics.successRate = Math.round(((investmentState.completedInvestments?.length || 0) / totalProjectsCount) * 100);
+    }
+    if (totalInvested > 0) {
+      investmentState.investmentMetrics.averageReturn = Math.round(((investmentState.portfolio.totalReturns || 0) / totalInvested) * 100);
+    }
+
+    // Промышленные проекты
+    const runningIndustryProjects = [];
+    (industryState.activeProjects || []).forEach((project) => {
+      const data = industrialProjects.find((item) => item.id === project.id);
+      if (!data) {
+        runningIndustryProjects.push(project);
+        return;
+      }
+
+      const projectEntry = { ...project };
+      projectEntry.monthsPassed = (projectEntry.monthsPassed || 0) + 1;
+
+      const progress = industryHelpers.simulateConstructionProgress(data, projectEntry.monthsPassed);
+      projectEntry.progress = progress.progressPercent;
+      projectEntry.remainingMonths = progress.remainingMonths;
+      projectEntry.status = progress.isCompleted ? IndustryProjectStatus.OPERATIONAL : progress.currentPhase;
+
+      if (progress.isCompleted) {
+        industryState.completedProjects = [
+          {
+            id: `${projectEntry.id}_${Date.now()}`,
+            projectId: projectEntry.id,
+            completedAt: Date.now(),
+            kickbacksReceived: projectEntry.kickbacksReceived || 0,
+            totalCost: projectEntry.totalCost || data.totalCost
+          },
+          ...(industryState.completedProjects || [])
+        ].slice(0, 25);
+
+        industryState.industryMetrics.totalEmployment = (industryState.industryMetrics?.totalEmployment || 0) + (data.jobs || 0);
+        industryState.industryMetrics.totalRevenue = (industryState.industryMetrics?.totalRevenue || 0) + (data.annualRevenue || 0);
+        industryState.industryMetrics.totalTaxRevenue = (industryState.industryMetrics?.totalTaxRevenue || 0) + (data.taxRevenue || 0);
+        industryState.industryMetrics.industrialCapacity = clamp((industryState.industryMetrics?.industrialCapacity || 0) + (data.benefits?.industrialCapacity || 0));
+
+        if (data.benefits?.unemployment) {
+          updatedState.unemployment = Math.max(0, (updatedState.unemployment || 0) + data.benefits.unemployment);
+        }
+        if (data.benefits?.infrastructure) {
+          updatedState.infrastructure = clamp((updatedState.infrastructure || 0) + data.benefits.infrastructure);
+        }
+        if (data.benefits?.mayorRating) {
+          updatedState.mayorRating = clamp(
+            (updatedState.mayorRating || 0) + data.benefits.mayorRating,
+            GameConstants.MIN_MAYOR_RATING,
+            GameConstants.MAX_MAYOR_RATING
+          );
+        }
+        if (data.benefits?.ecology) {
+          updatedState.ecology = clamp((updatedState.ecology || 0) + data.benefits.ecology);
+        }
+
+        if (data.benefits?.taxRevenue) {
+          financeState.cityBudget.monthlyIncome[IncomeTypes.BUSINESS_TAXES] =
+            (financeState.cityBudget.monthlyIncome?.[IncomeTypes.BUSINESS_TAXES] || 0) + Math.round(data.benefits.taxRevenue / 12);
+        }
+      } else {
+        runningIndustryProjects.push(projectEntry);
+      }
+    });
+    industryState.activeProjects = runningIndustryProjects;
+
+    // Силовые структуры
+    const activeThreats = [];
+    (securityState.activeThreats || []).forEach((threat) => {
+      const threatEntry = { ...threat };
+      threatEntry.age = (threatEntry.age || 0) + 1;
+      threatEntry.progress = clamp((threatEntry.progress || 50) - 10);
+      if (threatEntry.escalation) {
+        threatEntry.progress = clamp(threatEntry.progress + 15);
+      }
+      if (threatEntry.progress <= 0 && !threatEntry.escalation) {
+        return;
+      }
+      activeThreats.push(threatEntry);
+    });
+    securityState.activeThreats = activeThreats;
+
+    const generatedThreat = securityHelpers.generateRandomThreat({
+      ...updatedState,
+      securityState,
+      financeState,
+      industryState
+    });
+    if (generatedThreat) {
+      securityState.activeThreats = [
+        {
+          ...generatedThreat,
+          id: `${generatedThreat.id}_${Date.now()}`,
+          detectedAt: Date.now(),
+          progress: 60
+        },
+        ...securityState.activeThreats
+      ].slice(0, 5);
+      updatedState.media_attention = (updatedState.media_attention || 0) + 10;
+    }
+
+    const investigationRisk = securityHelpers.calculateInvestigationRisk({
+      ...updatedState,
+      industryState,
+      securityState,
+      financeState
+    });
+    securityState.securityMetrics = {
+      ...securityState.securityMetrics,
+      investigationProbability: clamp(investigationRisk, 0, 100),
+      corruptionRisk: clamp((securityState.securityMetrics?.corruptionRisk || 0) + securityState.activeThreats.length * 5, 0, 100),
+      overallThreatLevel: (() => {
+        if (securityState.activeThreats.some((threat) => threat.threat_level === ThreatLevels.CRITICAL)) return ThreatLevels.CRITICAL;
+        if (securityState.activeThreats.some((threat) => threat.threat_level === ThreatLevels.HIGH)) return ThreatLevels.HIGH;
+        if (securityState.activeThreats.length > 0) return ThreatLevels.MEDIUM;
+        return ThreatLevels.LOW;
+      })(),
+      protectionLevel: securityHelpers.calculateProtectionLevel(securityState.agencies || {})
+    };
+
+    // Граждане
+    const newIssue = citizenHelpers.generateRandomIssue({
+      ...updatedState,
+      citizensState
+    });
+    if (newIssue) {
+      citizensState.activeIssues = [newIssue, ...(citizensState.activeIssues || [])].slice(0, 10);
+      citizensState.communicationStats = {
+        ...(citizensState.communicationStats || {}),
+        totalIssues: (citizensState.communicationStats?.totalIssues || 0) + 1
+      };
+    }
+
+    const overallSatisfaction = citizenHelpers.calculateOverallSatisfaction(citizensState.groups);
+    citizensState.citizenMetrics = {
+      ...citizensState.citizenMetrics,
+      overallSatisfaction: clamp(overallSatisfaction),
+      complaintRate: clamp((citizensState.activeIssues?.length || 0) * 2, 0, 100)
+    };
+    updatedState.happiness = clamp((updatedState.happiness || 0) * 0.7 + overallSatisfaction * 0.3);
+
+    // Налоговая система
+    const totalRevenue = taxationHelpers.calculateTotalTaxRevenue(
+      taxationState.currentRates,
+      taxationState.taxBase,
+      taxationState.collectionEfficiency
+    );
+    taxationState.taxMetrics = {
+      ...taxationState.taxMetrics,
+      totalRevenue,
+      collectionRate: Math.round(
+        Object.values(taxationState.collectionEfficiency || {}).reduce((sum, efficiency) => sum + efficiency, 0) /
+        Math.max(1, Object.keys(taxationState.collectionEfficiency || {}).length)
+      )
+    };
+    taxationState.debt.debtToRevenue = totalRevenue > 0
+      ? Math.round((taxationState.debt.totalDebt / totalRevenue) * 100)
+      : taxationState.debt.debtToRevenue;
+
+    const totalExpenditure = Object.values(taxationState.expenditureStructure || {}).reduce((sum, entry) => sum + (entry.amount || 0), 0);
+    taxationState.expenditureStructure = Object.fromEntries(
+      Object.entries(taxationState.expenditureStructure || {}).map(([key, entry]) => [
+        key,
+        { ...entry, percentage: totalExpenditure > 0 ? (entry.amount / totalExpenditure) * 100 : 0 }
+      ])
+    );
+    const totalRevenueStructure = Object.values(taxationState.revenueStructure || {}).reduce((sum, entry) => sum + (entry.amount || 0), 0);
+    taxationState.revenueStructure = Object.fromEntries(
+      Object.entries(taxationState.revenueStructure || {}).map(([key, entry]) => [
+        key,
+        { ...entry, percentage: totalRevenueStructure > 0 ? (entry.amount / totalRevenueStructure) * 100 : 0 }
+      ])
+    );
+
+    // Строительные проекты
+    const runningConstructionProjects = [];
+    (constructionState.activeProjects || []).forEach((project) => {
+      const data = constructionProjects.find((item) => item.id === project.id);
+      if (!data) {
+        runningConstructionProjects.push(project);
+        return;
+      }
+
+      const projectEntry = { ...project };
+      projectEntry.monthsPassed = (projectEntry.monthsPassed || 0) + 1;
+
+      const progressPercent = Math.min(100, (projectEntry.monthsPassed / data.duration) * 100);
+      projectEntry.progress = progressPercent;
+
+      let phase = ConstructionPhases.PLANNING;
+      if (progressPercent >= 15) phase = ConstructionPhases.PERMITS;
+      if (progressPercent >= 35) phase = ConstructionPhases.FOUNDATION;
+      if (progressPercent >= 65) phase = ConstructionPhases.CONSTRUCTION;
+      if (progressPercent >= 85) phase = ConstructionPhases.FINISHING;
+      if (progressPercent >= 95) phase = ConstructionPhases.COMMISSIONING;
+      if (progressPercent >= 100) phase = ConstructionPhases.COMPLETED;
+      projectEntry.status = phase;
+
+      if (phase === ConstructionPhases.COMPLETED) {
+        constructionState.completedProjects = [
+          {
+            id: `${projectEntry.id}_${Date.now()}`,
+            projectId: projectEntry.id,
+            completedAt: Date.now(),
+            kickbacksReceived: projectEntry.kickbacksReceived || 0
+          },
+          ...(constructionState.completedProjects || [])
+        ].slice(0, 25);
+
+        if (data.benefits?.infrastructure) {
+          updatedState.infrastructure = clamp((updatedState.infrastructure || 0) + data.benefits.infrastructure);
+        }
+        if (data.benefits?.environmental) {
+          updatedState.ecology = clamp((updatedState.ecology || 0) + data.benefits.environmental);
+        }
+        if (data.benefits?.jobs_permanent) {
+          updatedState.unemployment = Math.max(0, (updatedState.unemployment || 0) - data.benefits.jobs_permanent * 0.01);
+        }
+      } else {
+        runningConstructionProjects.push(projectEntry);
+      }
+    });
+    constructionState.activeProjects = runningConstructionProjects;
+    constructionState.constructionMetrics.infrastructureIndex = constructionHelpers.calculateUtilityQuality(constructionState.utilities || {});
+
+    // Личные траты
+    personalSpendingState.totalSpent = (personalSpendingState.totalSpent || 0) + recurringExpenses;
+    personalSpendingState.monthlyExpenses = recurringExpenses;
+    personalSpendingState.totalAssets = personalSpendingHelpers.calculateAssetValue(personalSpendingState.assets || [], {
+      ...updatedState,
+      currentTimestamp: updatedState.currentTimestamp
+    });
+    personalSpendingState.detectionRisk = personalSpendingHelpers.calculateDetectionRisk(
+      personalSpendingState.spendingHistory || [],
+      {
+        ...updatedState,
+        financeState,
+        personalSpendingState
+      }
+    );
+    personalSpendingState.lifestyleQuality = personalSpendingHelpers.calculateLifestyleQuality(
+      personalSpendingState.assets || [],
+      personalSpendingState.recurringExpenses || []
+    );
+    personalSpendingState.familyHappiness = personalSpendingHelpers.calculateFamilyHappiness(
+      personalSpendingState.spendingHistory || [],
+      personalSpendingState.assets || []
+    );
+
+    // Финальные присваивания
+    updatedState.budget = Math.max(0, Math.round(budget));
+    updatedState.financeState = financeState;
+    updatedState.bankingState = bankingState;
+    updatedState.governmentState = governmentState;
+    updatedState.investmentState = investmentState;
+    updatedState.industryState = industryState;
+    updatedState.securityState = securityState;
+    updatedState.citizensState = citizensState;
+    updatedState.taxationState = taxationState;
+    updatedState.constructionState = constructionState;
+    updatedState.personalSpendingState = personalSpendingState;
+    updatedState.personalFinances = {
+      personal_account: financeState.personalFinances.accounts?.[PersonalAccountTypes.CHECKING] || 0,
+      savings_account: financeState.personalFinances.accounts?.[PersonalAccountTypes.SAVINGS] || 0,
+      offshore_account: financeState.personalFinances.accounts?.[PersonalAccountTypes.OFFSHORE] || 0,
+      crypto_account: financeState.personalFinances.accounts?.[PersonalAccountTypes.CRYPTO] || 0,
+      cash: financeState.personalFinances.accounts?.[PersonalAccountTypes.CASH] || 0,
+      monthlyIncome: { ...(financeState.personalFinances.monthlyIncome || {}) },
+      monthlyExpenses: { ...(financeState.personalFinances.monthlyExpenses || {}) }
+    };
+    updatedState.citizenGroups = { ...citizensState.groups };
+    updatedState.corruption_level = clamp(
+      ((financeState.risks?.investigationRisk || 0) + (financeState.risks?.publicSuspicion || 0)) / 2
+    );
+    updatedState.media_attention = clamp((updatedState.media_attention || 0) - 2 + securityState.activeThreats.length * 3, 0, 100);
+
+    // Естественные изменения показателей и случайные события
+    const decayedState = gameLogic.applyNaturalDecay(updatedState);
+
+    if (Math.random() < 0.3) {
+      const randomEvent = eventHelpers.getRandomEvent(decayedState);
       if (randomEvent) {
-        newState.pendingEvent = randomEvent;
+        decayedState.pendingEvent = randomEvent;
       }
     }
 
-    return newState;
+    return decayedState;
   },
 
   // Естественное ухудшение показателей
@@ -150,7 +795,13 @@ export const gameLogic = {
           year: state.currentYear
         },
         remainingDays: option.duration,
-        isEventProject: true
+        isEventProject: true,
+        budgetCategory: getBudgetCategoryForProject(event.category),
+        financials: {
+          upfrontCost: option.cost || 0,
+          monthlyCost: 0,
+          funding: []
+        }
       };
 
       newState.activeProjects = [...newState.activeProjects, project];
@@ -161,29 +812,209 @@ export const gameLogic = {
 
   // Запуск проекта
   startProject: (state, projectId) => {
-    return projectHelpers.startProject(state, projectId);
+    const project = cityProjects.find((item) => item.id === projectId);
+    if (!project) {
+      return { ...state, errorMessage: 'Проект не найден' };
+    }
+
+    const activeCount = (state.activeProjects || []).filter((item) => item.status === ProjectStatus.IN_PROGRESS).length;
+    if (activeCount >= GameConstants.MAX_ACTIVE_PROJECTS) {
+      return { ...state, errorMessage: 'Достигнут лимит активных проектов' };
+    }
+
+    if (!projectHelpers.canStartProject(project, state)) {
+      return { ...state, errorMessage: 'Условия для запуска проекта не выполнены' };
+    }
+
+    const financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+    const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+
+    const budgetCategory = getBudgetCategoryForProject(project.category);
+    const fundingAccounts = [
+      BankAccountTypes.CITY_CHECKING,
+      BankAccountTypes.CITY_SAVINGS,
+      BankAccountTypes.CITY_INVESTMENT
+    ];
+
+    const totalAvailable = fundingAccounts.reduce((sum, accountType) => {
+      const account = bankingState.accounts?.[accountType];
+      return sum + (account?.balance || 0);
+    }, 0);
+
+    if (totalAvailable < project.cost) {
+      return { ...state, errorMessage: 'Недостаточно средств для запуска проекта' };
+    }
+
+    let budget = state.budget ?? financeState.cityBudget.total ?? 0;
+    let remainingCost = project.cost;
+    const funding = [];
+
+    fundingAccounts.forEach((accountType) => {
+      if (remainingCost <= 0) return;
+      const account = bankingState.accounts?.[accountType];
+      if (!account) return;
+
+      const available = account.balance || 0;
+      if (available <= 0) return;
+
+      const deduction = Math.min(available, remainingCost);
+      if (deduction <= 0) return;
+
+      adjustBankAccountBalance(bankingState, accountType, -deduction);
+      budget += applyFinanceAccountChange(financeState, accountType, -deduction);
+      funding.push({ accountType, amount: deduction });
+      remainingCost -= deduction;
+    });
+
+    if (remainingCost > 0) {
+      adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, -remainingCost);
+      budget += applyFinanceAccountChange(financeState, BankAccountTypes.CITY_CHECKING, -remainingCost);
+      funding.push({ accountType: BankAccountTypes.CITY_CHECKING, amount: remainingCost });
+      remainingCost = 0;
+    }
+
+    financeState.cityBudget.spent = {
+      ...(financeState.cityBudget.spent || {}),
+      [budgetCategory]: Math.min(
+        (financeState.cityBudget.allocated?.[budgetCategory] || Infinity),
+        (financeState.cityBudget.spent?.[budgetCategory] || 0) + project.cost
+      )
+    };
+
+    if (project.monthlyCost) {
+      financeState.cityBudget.projectExpenses = {
+        ...(financeState.cityBudget.projectExpenses || {}),
+        [project.id]: {
+          projectId: project.id,
+          title: project.title,
+          category: budgetCategory,
+          monthlyCost: project.monthlyCost
+        }
+      };
+    }
+
+    bankingState.transactionHistory = appendTransaction(bankingState.transactionHistory, {
+      id: Date.now(),
+      type: 'start_city_project',
+      projectId: project.id,
+      amount: project.cost,
+      funding,
+      timestamp: Date.now()
+    });
+
+    const newProject = {
+      ...project,
+      status: ProjectStatus.IN_PROGRESS,
+      startDate: {
+        day: state.currentDay,
+        month: state.currentMonth,
+        year: state.currentYear
+      },
+      remainingDays: project.duration,
+      totalSpent: project.cost,
+      effectsApplied: false,
+      budgetCategory,
+      financials: {
+        upfrontCost: project.cost,
+        monthlyCost: project.monthlyCost || 0,
+        funding
+      }
+    };
+
+    const updatedProjects = [...(state.activeProjects || []), newProject];
+    const budgetDelta = (budget || 0) - (state.budget || 0);
+
+    return {
+      ...state,
+      errorMessage: null,
+      activeProjects: updatedProjects,
+      budget: Math.max(0, Math.round(budget)),
+      budget_balance: budgetDelta,
+      financeState,
+      bankingState,
+      personalFinances: buildPersonalFinancesSnapshot(financeState.personalFinances)
+    };
   },
 
   // Отмена проекта
   cancelProject: (state, projectId) => {
-    const project = state.activeProjects.find(p => p.id === projectId);
-    if (!project || project.status !== 'in_progress') return state;
+    const project = state.activeProjects.find((p) => p.id === projectId);
+    if (!project || project.status !== ProjectStatus.IN_PROGRESS) {
+      return state;
+    }
 
-    // Возвращаем часть средств (50%)
-    const refund = Math.floor(project.totalSpent * 0.5);
+    const baseSpent = project.totalSpent || project.cost || 0;
+    const refund = Math.floor(baseSpent * 0.5);
 
-    const updatedProjects = state.activeProjects.map(p => 
-      p.id === projectId 
-        ? { ...p, status: 'cancelled' }
+    const financeState = state.financeState ? deepClone(state.financeState) : deepClone(initialFinanceState);
+    const bankingState = state.bankingState ? deepClone(state.bankingState) : deepClone(initialBankingState);
+
+    let budget = state.budget ?? financeState.cityBudget.total ?? 0;
+    const funding = project.financials?.funding || [
+      { accountType: BankAccountTypes.CITY_CHECKING, amount: baseSpent }
+    ];
+    const totalFunding = funding.reduce((sum, entry) => sum + (entry.amount || 0), 0) || refund;
+    let remainingRefund = refund;
+
+    funding.forEach((entry, index) => {
+      if (remainingRefund <= 0) return;
+
+      const share = index === funding.length - 1
+        ? remainingRefund
+        : Math.min(remainingRefund, Math.round((refund * (entry.amount || 0)) / totalFunding));
+
+      adjustBankAccountBalance(bankingState, entry.accountType, share);
+      budget += applyFinanceAccountChange(financeState, entry.accountType, share);
+      remainingRefund -= share;
+    });
+
+    if (remainingRefund > 0) {
+      adjustBankAccountBalance(bankingState, BankAccountTypes.CITY_CHECKING, remainingRefund);
+      budget += applyFinanceAccountChange(financeState, BankAccountTypes.CITY_CHECKING, remainingRefund);
+      remainingRefund = 0;
+    }
+
+    if (project.budgetCategory) {
+      const currentSpent = financeState.cityBudget.spent?.[project.budgetCategory] || 0;
+      financeState.cityBudget.spent = {
+        ...(financeState.cityBudget.spent || {}),
+        [project.budgetCategory]: Math.max(0, currentSpent - refund)
+      };
+    }
+
+    if (financeState.cityBudget.projectExpenses?.[project.id]) {
+      const updatedProjectExpenses = { ...financeState.cityBudget.projectExpenses };
+      delete updatedProjectExpenses[project.id];
+      financeState.cityBudget.projectExpenses = updatedProjectExpenses;
+    }
+
+    bankingState.transactionHistory = appendTransaction(bankingState.transactionHistory, {
+      id: Date.now(),
+      type: 'cancel_city_project',
+      projectId: project.id,
+      amount: refund,
+      timestamp: Date.now()
+    });
+
+    const updatedProjects = state.activeProjects.map((p) =>
+      p.id === projectId
+        ? { ...p, status: ProjectStatus.CANCELLED, remainingDays: 0 }
         : p
     );
 
+    const budgetDelta = (budget || 0) - (state.budget || 0);
+
     return {
       ...state,
-      budget: state.budget + refund,
+      errorMessage: null,
       activeProjects: updatedProjects,
-      failedProjects: state.failedProjects + 1,
-      mayorRating: Math.max(0, state.mayorRating - 5) // штраф к рейтингу
+      budget: Math.max(0, Math.round(budget)),
+      budget_balance: budgetDelta,
+      financeState,
+      bankingState,
+      personalFinances: buildPersonalFinancesSnapshot(financeState.personalFinances),
+      failedProjects: (state.failedProjects || 0) + 1,
+      mayorRating: Math.max(0, state.mayorRating - 5)
     };
   },
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,18 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-import path from 'path'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
-})
+});


### PR DESCRIPTION
## Summary
- track active project costs inside the finance state and expose helpers to combine recurring and project-driven expenses【F:src/types/finance.js†L122-L135】【F:src/types/finance.js†L217-L265】
- update the core game logic to debit city accounts when launching projects, refund on cancellation, and fold project costs into monthly budget updates【F:src/utils/gameLogic.js†L152-L195】【F:src/utils/gameLogic.js†L814-L1017】
- refresh the budget manager UI to surface combined monthly expenses and a breakdown of ongoing project spending, and feed consumers the actual available project list from the context【F:src/components/BudgetManager.jsx†L135-L144】【F:src/components/BudgetManager.jsx†L243-L578】【F:src/contexts/GameContext.jsx†L2742-L2747】

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d19b47fb5c83299a8606ac6b28b681